### PR TITLE
use reactid data attr as querySelector

### DIFF
--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -363,6 +363,10 @@ var Mixin = {
         }
 
         tmpSteps.forEach(function (s) {
+            if (s.selector.dataset && s.selector.dataset.reactid) {
+                var reactSelector = '[data-reactid="' + s.selector.dataset.reactid + '"]'
+                s.selector = reactSelector;
+            }
             el = document.querySelector(s.selector);
             s.position = s.position || 'top';
 


### PR DESCRIPTION
I found it was useful to use a DOM node as a selector. This way, you can use a component's ref to get the node: `var node = React.findDOMNode(this.refs.[some-ref])` which can be used to get the react id with `node.dataset.reactid`. 