### PR TITLE
Stores bound event listeners for proper removal on component unmount

### DIFF
--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -296,10 +296,12 @@ var Mixin = {
         }
 
         joyride.mixin = this;
-        window.addEventListener('resize', joyride.calcPlacement.bind(this));
+        this._resizeListener = joyride.calcPlacement.bind(this);
+        window.addEventListener('resize', this._resizeListener);
 
         if (this.state.joyrideKeyboardNavigation) {
-            document.body.addEventListener('keydown', joyride.keyboardNavigation.bind(this));
+            this._keydownListener = joyride.keyboardNavigation.bind(this);
+            document.body.addEventListener('keydown', this._keydownListener);
         }
     },
 
@@ -307,9 +309,9 @@ var Mixin = {
         this._joyrideUnrenderLayer();
         document.body.removeChild(this._target);
 
-        window.removeEventListener('resize', joyride.calcPlacement.bind(this));
+        window.removeEventListener('resize', this._resizeListener);
         if (this.state.joyrideKeyboardNavigation) {
-            document.body.removeEventListener('keydown', joyride.keyboardNavigation.bind(this));
+            document.body.removeEventListener('keydown', this._keydownListener);
         }
     },
 


### PR DESCRIPTION
`Function.prototype.bind` will return a different function in each individual case where it is invoked on `joyride.calcPlacement`. This means that the event listeners registered in `componentDidMount` are different functions from those which are "removed" in `componentWillUnmount` (with the result that the original event listeners won't be removed there). This commit stores references to the original event listeners so that they can be removed via those references on unmounting.