### PR TITLE
Adds methods for clearing and slicing the steps in a joyride

### DIFF
--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -355,6 +355,28 @@ var Mixin = {
     },
 
     /**
+     * Clears any steps stored in joyride.steps, for the purpose of effectively
+     * resetting/restarting a joyride with new steps without going through the
+     * previously-existing steps again (since joyrideAddSteps simply pushes
+     * new steps).
+     */
+    joyrideClearSteps: function () {
+        joyride.steps = [];
+    },
+
+    /**
+     * Applies Array.prototype.slice to the joyride.steps array, allowing more
+     * fine-grained manipulation of the steps.
+     * @param {number} [startStepInclusive] - index at which to begin the slice
+     *  (inclusive)
+     * @param {number} [endStepExclusive] - index at which to stop the slice
+     *  (exclusive)
+     */
+    joyrideSliceSteps: function (startStepInclusive, endStepExclusive) {
+        joyride.steps = joyride.steps.slice(startStepInclusive, endStepExclusive);
+    },
+
+    /**
      * Add Steps
      * @param {array|object} steps - Steps to add to the tour
      * @param {boolean} [start] - Starts the tour right away


### PR DESCRIPTION
As a user of react-joyride, I've found the need to sometimes be able to clear (or slice -- I've included both methods here for convenience) the steps in a joyride. For example, one of my applications has a joyride that is not "continuous" (it stops after a certain user action, then continues after another user action). Specifically, the application automatically presents a few instructions informing the user what he/she can do, then waits for the user to do something, and then restarts the joyride at a certain step depending on what the user does (like "drill down" instructions). The joyride is managed by an overarching React controller view that determines when the joyride is started and which steps to execute. These methods make it easy to do that with a single joyride controlled by that view.