### PR TITLE
[fix] make joyrideReplaceSteps respect user-specified false

### DIFF
--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -423,7 +423,7 @@ var Mixin = {
      */
     joyrideReplaceSteps: function (steps, restart) {
         steps = steps || [];
-        restart = restart || true;
+        restart = restart !== false;
 
         joyride.steps = joyride.parseSteps(steps);
         joyride.skipped = false;


### PR DESCRIPTION
Old code will ignore a `false` value for `restart` even if the caller passes it explicitly, because `restart || true` will always evaluate to `true`. This commit makes it so that restart is `true` by default (i.e., when the user does not explicitly pass `false`), but otherwise respect's the caller's wishes.