### PR TITLE
Add debouncing for resize event, fix repositioning of tooltips

### DIFF
--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -371,7 +371,7 @@ var Mixin = {
                     timeoutId = setTimeout(function() {
                         timeoutId = null;
                         joyride.calcPlacement.call(joyride.mixin);
-                    }, 100);
+                    }, 200);
                 }
             }());
         }

--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -17,6 +17,7 @@ var joyride = {
     mixin: false,
     options: {
         debug: false,
+        doDebounceResize: true,
         keyboardNavigation: true,
         locale: {
             back: 'Back',
@@ -190,7 +191,7 @@ var joyride = {
                 y: -1000
             };
 
-        if (step && (!/animate/.test(component.className) || state._joyrideXPos < 0)) {
+        if (step) {
             position = step.position;
             body = document.body.getBoundingClientRect();
             target = document.querySelector(step.selector).getBoundingClientRect();
@@ -358,7 +359,22 @@ var Mixin = {
         }
 
         joyride.mixin = this;
-        joyride.listeners.resize = joyride.calcPlacement.bind(this);
+
+        if (!joyride.options.doDebounceResize) {
+            joyride.listeners.resize = joyride.calcPlacement.bind(this);
+        } else {
+            // Debounce so that the resize listener is not called too often
+            joyride.listeners.resize = (function() {
+                var timeoutId;
+                return function() {
+                    clearTimeout(timeoutId);
+                    timeoutId = setTimeout(function() {
+                        timeoutId = null;
+                        joyride.calcPlacement.call(joyride.mixin);
+                    }, 100);
+                }
+            }());
+        }
         window.addEventListener('resize', joyride.listeners.resize);
 
         if (joyride.options.keyboardNavigation) {

--- a/lib/scripts/Mixin.js
+++ b/lib/scripts/Mixin.js
@@ -372,7 +372,7 @@ var Mixin = {
                         timeoutId = null;
                         joyride.calcPlacement.call(joyride.mixin);
                     }, 200);
-                }
+                };
             }());
         }
         window.addEventListener('resize', joyride.listeners.resize);


### PR DESCRIPTION
Closes #21.

This commit allows tooltips to reposition themselves correctly, while at the same time preventing frequent state updates by debouncing the resize event so that the resize listener (which ultimately calls `calcPlacement`) only fires at the end of resizing, rather than repeatedly. It also adds a `doDebounceResize` option that is set to `true` by default, but that can be set to `false` if a user (for some reason) wants to override this behavior.