### PR TITLE
Further Implement BEM-style CSS classes

### DIFF
--- a/lib/scripts/Beacon.js
+++ b/lib/scripts/Beacon.js
@@ -76,11 +76,11 @@ var Beacon = React.createClass({
                     onMouseEnter: props.eventType === 'hover' && !isTouch ? props.onTrigger : null
                 },
                 React.createElement('span', {
-                    className: 'inner',
+                    className: 'joyride-beacon__inner',
                     style: styles.inner
                 }),
                 React.createElement('span', {
-                    className: 'outer',
+                    className: 'joyride-beacon__outer',
                     style: styles.outer
                 })
             )

--- a/lib/scripts/Component.js
+++ b/lib/scripts/Component.js
@@ -446,7 +446,7 @@ var Component = React.createClass({
             newIndex = props.steps.length + 1;
         }
 
-        if (tooltip.classList.contains('standalone')) {
+        if (tooltip.classList.contains('joyride-tooltip--standalone')) {
             this.setState({
                 play: this.state.previousPlay,
                 previousPlay: undefined,

--- a/lib/scripts/Tooltip.js
+++ b/lib/scripts/Tooltip.js
@@ -222,7 +222,7 @@ var Tooltip = React.createClass({
                 'data-target': step.selector
             },
             React.createElement('div', {
-                className: 'triangle triangle-' + opts.positionClass,
+                className: 'joyride-tooltip__triangle joyride-tooltip__triangle-' + opts.positionClass,
                 style: styles.arrow
             }),
             React.createElement('a', {

--- a/lib/scripts/Tooltip.js
+++ b/lib/scripts/Tooltip.js
@@ -204,7 +204,7 @@ var Tooltip = React.createClass({
         }
         opts.classes.push(opts.positionClass);
         if (props.animate) {
-            opts.classes.push('animate');
+            opts.classes.push('joyride-tooltip--animate');
         }
 
         if (step.title) {

--- a/lib/scripts/Tooltip.js
+++ b/lib/scripts/Tooltip.js
@@ -197,7 +197,7 @@ var Tooltip = React.createClass({
         styles = this._setStyles(opts, styles, step.style)
 
         if (props.standalone) {
-            opts.classes.push('standalone');
+            opts.classes.push('joyride-tooltip--standalone');
         }
         if (opts.positonBaseClass) {
             opts.classes.push(opts.positonBaseClass);

--- a/lib/scripts/Tooltip.js
+++ b/lib/scripts/Tooltip.js
@@ -243,7 +243,7 @@ var Tooltip = React.createClass({
                 (props.buttons.skip ?
                     React.createElement('a', {
                         href: '#',
-                        className: 'skip',
+                        className: 'joyride-tooltip__button joyride-tooltip__button--skip',
                         style: styles.buttons.skip,
                         'data-type': 'skip',
                         onClick: props.onClick
@@ -252,7 +252,7 @@ var Tooltip = React.createClass({
                 (props.buttons.secondary ?
                     React.createElement('a', {
                         href: '#',
-                        className: 'secondary',
+                        className: 'joyride-tooltip__button joyride-tooltip__button--secondary',
                         style: styles.buttons.back,
                         'data-type': 'back',
                         onClick: props.onClick
@@ -260,7 +260,7 @@ var Tooltip = React.createClass({
                     : false),
                 React.createElement('a', {
                     href: '#',
-                    className: 'primary',
+                    className: 'joyride-tooltip__button joyride-tooltip__button--primary',
                     style: styles.buttons.primary,
                     'data-type': 'next',
                     onClick: props.onClick

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -302,7 +302,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
       }
     }
 
-    &.standalone {
+    &--standalone {
       .joyride-tooltip__main {
         padding-bottom: 0;
       }

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -146,7 +146,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
       animation-timing-function: $joyride-tooltip-animation-timing;
     }
 
-    .triangle {
+    &__triangle {
       background-repeat: no-repeat;
       overflow: hidden;
       position: absolute;
@@ -157,7 +157,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
     &.bottom-right {
       margin-top: $joyride-tooltip-arrow-height;
 
-      .triangle {
+      .joyride-tooltip__triangle {
         background-image: url(joyride-arrow(bottom));
         height: $joyride-tooltip-arrow-height;
         left: 50%;
@@ -172,7 +172,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
     &.top-right {
       margin-bottom: $joyride-tooltip-arrow-height;
 
-      .triangle {
+      .joyride-tooltip__triangle {
         background-image: url(joyride-arrow(top));
         bottom: -($joyride-tooltip-arrow-height - 2);
         height: $joyride-tooltip-arrow-height;
@@ -184,7 +184,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
 
     &.bottom-left,
     &.top-left {
-      .triangle {
+      .joyride-tooltip__triangle {
         left: 3%;
         transform: translateX(0);
 
@@ -196,7 +196,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
 
     &.bottom-right,
     &.top-right {
-      .triangle {
+      .joyride-tooltip__triangle {
         left: auto;
         right: 3%;
         transform: translateX(0);
@@ -210,7 +210,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
     &.left {
       margin-right: $joyride-tooltip-arrow-height;
 
-      .triangle {
+      .joyride-tooltip__triangle {
         background-image: url(joyride-arrow(left));
         height: $joyride-tooltip-arrow-size;
         right: -($joyride-tooltip-arrow-height - 2);
@@ -221,7 +221,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
     &.right {
       margin-left: $joyride-tooltip-arrow-height;
 
-      .triangle {
+      .joyride-tooltip__triangle {
         background-image: url(joyride-arrow(right));
         height: $joyride-tooltip-arrow-size;
         left: -($joyride-tooltip-arrow-height - 2);

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -70,7 +70,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
     width: $joyride-beacon-size;
     z-index: $joyride-zindex;
 
-    .inner {
+    &__inner {
       animation: joyride-beacon-inner 1.2s infinite ease-in-out;
       background-color: $joyride-beacon-color;
       border-radius: 50%;
@@ -84,7 +84,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
       width: 50%;
     }
 
-    .outer {
+    &__outer {
       animation: joyride-beacon-outer 1.2s infinite ease-in-out;
       background-color: rgba($joyride-beacon-color, 0.2);
       border: ($joyride-beacon-size / 18) solid $joyride-beacon-color;

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -274,8 +274,10 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
 
     &__footer {
       text-align: right;
+    }
 
-      .primary {
+    &__button {
+      &--primary {
         background-color: $joyride-button-bg-color;
         border-radius: $joyride-button-radius;
         color: $joyride-button-color;
@@ -289,13 +291,13 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
         }
       }
 
-      .secondary {
+      &--secondary {
         color: $joyride-back-button-color;
         margin-right: 10px;
         outline: none;
       }
 
-      .skip {
+      &--skip {
         color: $joyride-skip-button-color;
         float: left;
         margin-right: 10px;

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -141,7 +141,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
       width: nth($joyride-tooltip-width, 3);
     }
 
-    &.animate {
+    &--animate {
       animation: $joyride-tooltip-animation;
       animation-timing-function: $joyride-tooltip-animation-timing;
     }


### PR DESCRIPTION
Some of the CSS classes/selectors used common classnames such as `.animate`, `.primary`, etc... This causes conflicts when introducing `react-joyride` into existing applications that have polluted CSS selectors. Example, if CSS such as below exists in an application, the classnames/styles will conflict:

```css
/* Conflicting/Global classes */
.primary {
  color: blue;
  font-size: 28px;
}
.secondary {
  color: red;
  font-size: 12px;
}
```

Affected selectors:

- `.joyride-tooltip__triangle`
- `.joyride-beacon__{inner,outer}`
- `.joyride-tooltip__button--{primary, secondary, skip}`
- `.joyride-tooltip--animate`
- `.joyride-tooltip--standalone`

The changes are split up/isolated into individual commits for ease of review.

---

:memo: I was unable to get the `demo` branch up and running locally to test this in the browser. I ran into many issues relating to what looks related to the build step, babel, and/or linting.

```
[SyntaxError: app/scripts/components/Charts.jsx: A semicolon is required after a class property (11:5) while parsing file: /Users/erikaybar/Projects/GitHubRepos/gilbarbara/react-joyride-demo/app/scripts/components/Charts.jsx]
  pos: 227,
  loc: Position { line: 11, column: 5 },
  _babel: true,
// ...
```

Also, thanks a ton for this `react-joyride` @gilbarbara it is working fantastically for our purposes so far :+1:!