### PR TITLE
possible fix for calculating doc height

### DIFF
--- a/lib/scripts/Component.js
+++ b/lib/scripts/Component.js
@@ -579,7 +579,10 @@ var Component = React.createClass({
    */
   _preventWindowOverflow: function(value, axis, elWidth, elHeight) {
     var winWidth  = window.innerWidth,
-        docHeight = document.body.offsetHeight,
+        body      = document.body,
+        html      = document.documentElement,
+        docHeight =  Math.max( body.scrollHeight, body.offsetHeight,
+                      html.clientHeight, html.scrollHeight, html.offsetHeight ),
         newValue  = value;
 
     if (axis === 'x') {


### PR DESCRIPTION
In function _preventWindowOverflow of component.js, docHeight was assigned incorrect values in some cases. Changed the way doc height was calculated.
http://stackoverflow.com/questions/1145850/how-to-get-height-of-entire-document-with-javascript