### PR TITLE
Remove usage of window to allow server rendering

### DIFF
--- a/lib/scripts/Beacon.js
+++ b/lib/scripts/Beacon.js
@@ -1,7 +1,11 @@
 var React    = require('react'),
     hexToRGB = require('./utils.js').hexToRgb;
 
-var isTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints;
+var isTouch = false;
+
+if (typeof window !== 'undefined') {
+  isTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints;
+}
 
 var Beacon = React.createClass({
   displayName: 'JoyrideBeacon',

--- a/lib/scripts/Component.js
+++ b/lib/scripts/Component.js
@@ -1,5 +1,4 @@
 var React   = require('react'),
-    scroll  = require('scroll'),
     Beacon  = require('./Beacon'),
     Tooltip = require('./Tooltip');
 
@@ -14,7 +13,11 @@ var defaultState = {
     listeners    = {
       tooltips: {}
     },
-    isTouch      = 'ontouchstart' in window || navigator.msMaxTouchPoints;
+    isTouch      = false;
+
+if (typeof window !== 'undefined') {
+  isTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints;
+}
 
 var Component = React.createClass({
   displayName: 'Joyride',
@@ -133,6 +136,7 @@ var Component = React.createClass({
     }
 
     if (state.play && props.scrollToSteps && (props.scrollToFirstStep || (state.index > 0 || prevState.index > state.index))) {
+      var scroll  = require('scroll');
       scroll.top(this._getBrowser() === 'firefox' ? document.documentElement : document.body, this._getScrollTop());
     }
   },


### PR DESCRIPTION
In order to allow this component to be used inside of a project that has server rendering, you cannot call window besides component did mount. 

This is a fix that allows this component to be included in such project. However, not sure if I created a problem for the touch thing.