### PR TITLE
Make listeners variable an instance variable

### DIFF
--- a/lib/scripts/Component.js
+++ b/lib/scripts/Component.js
@@ -11,9 +11,6 @@ var defaultState = {
       yPos: -1000,
       skipped: false
     },
-    listeners    = {
-      tooltips: {}
-    },
     isTouch      = 'ontouchstart' in window || navigator.msMaxTouchPoints;
 
 var Component = React.createClass({
@@ -70,6 +67,12 @@ var Component = React.createClass({
   getInitialState: function() {
     return defaultState;
   },
+  
+  componentWillMount() {
+    this.listeners = {
+      tooltips: {}
+    };
+  },
 
   componentDidMount: function() {
     var props = this.props;
@@ -80,7 +83,7 @@ var Component = React.createClass({
       var self = this,
           timeoutId;
 
-      listeners.resize = (function() {
+      this.listeners.resize = (function() {
         return function() {
           clearTimeout(timeoutId);
           timeoutId = setTimeout(function() {
@@ -91,27 +94,27 @@ var Component = React.createClass({
       }());
     }
     else {
-      listeners.resize = this._calcPlacement;
+      this.listeners.resize = this._calcPlacement;
     }
-    window.addEventListener('resize', listeners.resize);
+    window.addEventListener('resize', this.listeners.resize);
 
     if (props.keyboardNavigation) {
-      listeners.keyboard = this._keyboardNavigation;
-      document.body.addEventListener('keydown', listeners.keyboard);
+      this.listeners.keyboard = this._keyboardNavigation;
+      document.body.addEventListener('keydown', this.listeners.keyboard);
     }
   },
 
   componentWillUnmount: function() {
-    window.removeEventListener('resize', listeners.resize);
+    window.removeEventListener('resize', this.listeners.resize);
 
     if (this.props.keyboardNavigation) {
-      document.body.removeEventListener('keydown', listeners.keyboard);
+      document.body.removeEventListener('keydown', this.listeners.keyboard);
     }
 
-    if (Object.keys(listeners.tooltips).length) {
-      Object.keys(listeners.tooltips).forEach(function(key) {
-        document.querySelector(key).removeEventListener(listeners.tooltips[key].event, listeners.tooltips[key].cb);
-        delete listeners.tooltips[key];
+    if (Object.keys(this.listeners.tooltips).length) {
+      Object.keys(this.listeners.tooltips).forEach(function(key) {
+        document.querySelector(key).removeEventListener(this.listeners.tooltips[key].event, this.listeners.tooltips[key].cb);
+        delete this.listeners.tooltips[key];
       });
     }
   },
@@ -269,21 +272,21 @@ var Component = React.createClass({
     el.dataset.tooltip = JSON.stringify(data);
 
     if (eventType === 'hover' && !isTouch) {
-      listeners.tooltips[key] = { event: 'mouseenter', cb: this._onTooltipTrigger };
-      listeners.tooltips[key + 'mouseleave'] = { event: 'mouseleave', cb: this._onTooltipTrigger };
-      listeners.tooltips[key + 'click'] = {
+      this.listeners.tooltips[key] = { event: 'mouseenter', cb: this._onTooltipTrigger };
+      this.listeners.tooltips[key + 'mouseleave'] = { event: 'mouseleave', cb: this._onTooltipTrigger };
+      this.listeners.tooltips[key + 'click'] = {
         event: 'click', cb: function(e) {
           e.preventDefault();
         }
       };
 
-      el.addEventListener('mouseenter', listeners.tooltips[key].cb);
-      el.addEventListener('mouseleave', listeners.tooltips[key + 'mouseleave'].cb);
-      el.addEventListener('click', listeners.tooltips[key + 'click'].cb);
+      el.addEventListener('mouseenter', this.listeners.tooltips[key].cb);
+      el.addEventListener('mouseleave', this.listeners.tooltips[key + 'mouseleave'].cb);
+      el.addEventListener('click', this.listeners.tooltips[key + 'click'].cb);
     }
     else {
-      listeners.tooltips[key] = { event: 'click', cb: this._onTooltipTrigger };
-      el.addEventListener('click', listeners.tooltips[key].cb);
+      this.listeners.tooltips[key] = { event: 'click', cb: this._onTooltipTrigger };
+      el.addEventListener('click', this.listeners.tooltips[key].cb);
     }
   },
 


### PR DESCRIPTION
Instead of using a closure for storing event listener references, use an instance variable.

Rationale:
I'm using multiple instances of Joyride so that I can have multiple beacons visible at once. Using a closure, we can only store one set of event listener references. By using an instance variable that get's initialized on `componentWillMount`, we can have multiple Joyrides instantiated at the same time.