### PR TITLE
don't calculate the position if the joyride hasn't started

### DIFF
--- a/lib/scripts/Component.js
+++ b/lib/scripts/Component.js
@@ -127,9 +127,7 @@ var Component = React.createClass({
     var props = this.props,
         state = this.state;
 
-    if ((state.tooltip || (state.play && props.steps[state.index])) && state.xPos < 0) {
-      this._calcPlacement();
-    }
+    this._calcPlacement();
 
     if (prevProps.steps.length !== props.steps.length) {
       this._log(['joyride:changedSteps', this.props.steps]);
@@ -524,7 +522,7 @@ var Component = React.createClass({
           y: -1000
         };
 
-    if (step) {
+    if (((state.tooltip || (state.play && props.steps[state.index])) && state.xPos < 0) && step) {
       position = step.position;
       body = document.body.getBoundingClientRect();
       target = document.querySelector(step.selector).getBoundingClientRect();


### PR DESCRIPTION
This is throwing so many errors on browser resize before or after the joyride has run.