### PR TITLE
Add click event for joyride-hole

### DIFF
--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -550,6 +550,16 @@ export default class Joyride extends React.Component {
           });
         }
       }
+
+      if (e.target.classList.contains('joyride-hole')) {
+        if (typeof props.callback === 'function') {
+          props.callback({
+            action: 'click',
+            type: 'hole',
+            step: props.steps[state.index]
+          });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Hi Gil,

What do you think about enabling click events for the joyride-hole? In testing our app we found that some users' intuitive response was to click the highlighted element during the tour, expecting it to work. Right now we can capture click events from the overlay but clicks on the hole itself are lost.

Or perhaps this could be enabled with a prop to maintain backwards compatibility?

-Kyle O
