### PR TITLE
tooltips are not showing

### DIFF
--- a/src/scripts/Tooltip.jsx
+++ b/src/scripts/Tooltip.jsx
@@ -34,14 +34,16 @@ export default class JoyrideTooltip extends React.Component {
   };
 
   componentDidMount() {
-    this.forceUpdate(this.props.onRender);
+    this.forceUpdate();
+    this.props.onRender();
   }
 
   componentDidUpdate(prevProps) {
-    const { onRender, step } = this.props;
+    const { step } = this.props;
 
     if (prevProps.step.selector !== step.selector) {
-      this.forceUpdate(onRender);
+      this.forceUpdate();
+      this.props.onRender();
     }
   }
 


### PR DESCRIPTION
looks like onRenderTooltip is not being called from the Tooltip on componentDidMount and componentDidUpdate. forceUpdate its not calling its callback. Calling onRender after forceUpdate make tooltip appears. (react 15.3.2)