### PR TITLE
Add `next()` to joyride API (fixes #140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,13 @@ Call this method to start the tour.
 
 - `autorun` {boolean} - Starts the tour with the first tooltip opened.
 
+### this.joyride.next()
+
+Call this method to programmatically advance to the next step of the tour.
+
 ### this.joyride.stop()
 
-Call this method to stop/pause the tour.
+Call this method to stop/pause the tour.  Call `this.joyride.start(true)` to restart.
 
 ### this.joyride.reset(restart)
 

--- a/lib/scripts/Joyride.js
+++ b/lib/scripts/Joyride.js
@@ -5,6 +5,8 @@
    */},{key:'start',value:function start(autorun){var _this3=this;var autoStart=autorun===true;this.logger('joyride:start',['autorun:',autoStart]);this.setState({play:true},function(){if(autoStart){_this3.toggleTooltip(true);}});}/**
    * Stop the tour
    */},{key:'stop',value:function stop(){this.logger('joyride:stop');this.setState({showTooltip:false,play:false});}/**
+   * Move to the next step, if there is one.  If there is no next step, hide the tooltip.
+   */},{key:'next',value:function next(){var state=this.state;var steps=this.props.steps;var nextIndex=state.index+1;var hasSteps=Boolean(steps[nextIndex]);var shouldDisplay=hasSteps&&state.showTooltip;this.logger('joyride:next',['new index:',nextIndex]);this.toggleTooltip(shouldDisplay,state.index+1,'next');}/**
    * Reset Tour
    *
    * @param {boolean} [restart] - Starts the new tour right away

--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -219,6 +219,19 @@ export default class Joyride extends React.Component {
   }
 
   /**
+   * Move to the next step, if there is one.  If there is no next step, hide the tooltip.
+   */
+  next() {
+    const state = this.state;
+    const { steps } = this.props;
+    const nextIndex = state.index + 1;
+    const hasSteps = Boolean(steps[nextIndex]);
+    const shouldDisplay = hasSteps && state.showTooltip;
+    this.logger('joyride:next', ['new index:', nextIndex]);
+    this.toggleTooltip(shouldDisplay, state.index + 1, 'next');
+  }
+
+  /**
    * Reset Tour
    *
    * @param {boolean} [restart] - Starts the new tour right away


### PR DESCRIPTION
### What
This adds an API to be able to programmatically advance to the next step.  

### Why
An example of where this may come in handy is a tooltip instructing the user to click on a particular UI element.  Ideally, we would want to disable the default "next" button on the tooltip, and wait until the user clicks on the desired element before advancing to the next step.

### Details
I used the `onKeyboardNavigation` method as a reference for implementing this.  
