### PR TITLE
Use markdown links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var App = React.createClass({
 Don't forget to pass a `ref` to the component.
 
 ### Styles
- 
+
 If your are using **SCSS** (and you should):
 
 ```scss
@@ -64,11 +64,11 @@ addSteps: function (steps) {
 	if (!Array.isArray(steps)) {
 	    steps = [steps];
 	}
-	
+
 	if (!steps.length) {
 	    return false;
 	}
-	
+
 	this.setState(function(currentState) {
 	    currentState.steps = currentState.steps.concat(this.joyride.parseSteps(steps));
 	    return currentState;
@@ -350,7 +350,6 @@ Copyright © 2016 Gil Barbara - [MIT License](LICENSE)
 ---
 
 Inspired by [react-tour-guide](https://github.com/jakemmarsh/react-tour-guide) and [jquery joyride tour](http://zurb.com/playground/jquery-joyride-feature-tour-plugin)
-  
 
 [npm-image]: https://badge.fury.io/js/react-joyride.svg
 [npm-url]: https://www.npmjs.com/package/react-joyride

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 React Joyride
 ===
 
-<a href="https://www.npmjs.com/package/react-joyride" target="_blank">![](https://badge.fury.io/js/react-joyride.svg)</a> <a href="https://travis-ci.org/gilbarbara/react-joyride" target="_blank">![](https://travis-ci.org/gilbarbara/react-joyride.svg)</a> <a href="https://codeclimate.com/github/gilbarbara/react-joyride">![](https://codeclimate.com/github/gilbarbara/react-joyride/badges/gpa.svg)</a> <a href="https://gitter.im/gilbarbara/react-joyride?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge">![Join the chat at https://gitter.im/gilbarbara/react-joyride](https://badges.gitter.im/Join%20Chat.svg)</a>
+[![NPM version][npm-image]][npm-url]
+[![build status][travis-image]][travis-url]
+[![Code Climate status][codeclimate-image]][codeclimate-url]
+[![Join the chat at https://gitter.im/gilbarbara/react-joyride][gitter-image]][gitter-url]
 
-<a href="http://gilbarbara.github.io/react-joyride/" target="_blank">![](http://gilbarbara.github.io/react-joyride/media/example.png)</a>
+[![Joyride example image][example-image]][example-url]
 
-View the demo <a href="http://gilbarbara.github.io/react-joyride/" target="_blank">here</a>. [[source](https://github.com/gilbarbara/react-joyride/tree/demo)]
+View the demo [here](http://gilbarbara.github.io/react-joyride/) [[source](https://github.com/gilbarbara/react-joyride/tree/demo)]
 
 [![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.3.0/dist/gratipay.svg)](https://gratipay.com/React-Joyride/)
 
@@ -349,3 +352,13 @@ Copyright © 2016 Gil Barbara - [MIT License](LICENSE)
 Inspired by [react-tour-guide](https://github.com/jakemmarsh/react-tour-guide) and [jquery joyride tour](http://zurb.com/playground/jquery-joyride-feature-tour-plugin)
   
 
+[npm-image]: https://badge.fury.io/js/react-joyride.svg
+[npm-url]: https://www.npmjs.com/package/react-joyride
+[travis-image]: https://travis-ci.org/gilbarbara/react-joyride.svg
+[travis-url]: https://travis-ci.org/gilbarbara/react-joyride
+[codeclimate-image]: https://codeclimate.com/github/gilbarbara/react-joyride/badges/gpa.svg
+[codeclimate-url]: https://codeclimate.com/github/gilbarbara/react-joyride
+[gitter-image]: https://badges.gitter.im/Join%20Chat.svg
+[gitter-url]: https://gitter.im/eslint/eslint?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[example-image]: http://gilbarbara.github.io/react-joyride/media/example.png
+[example-url]: http://gilbarbara.github.io/react-joyride/

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ var react = require('react');
 var Joyride = require('react-joyride');
 
 var App = React.createClass({
-	render: function () {
-		return (
-			<div className="app">
-				<Joyride ref={c => (this.joyride = c)} steps={this.state.steps} debug={true} ... />
-				<YourComponents .../>
-			</div>
-		);
-	}
+  render: function () {
+    return (
+      <div className="app">
+        <Joyride ref={c => (this.joyride = c)} steps={this.state.steps} debug={true} ... />
+        <YourComponents .../>
+      </div>
+    );
+  }
   ...
 });
 ```
@@ -61,22 +61,22 @@ Add a custom method to include steps to your component state (or store).
 
 ```javascript
 addSteps: function (steps) {
-	if (!Array.isArray(steps)) {
-	    steps = [steps];
-	}
+  if (!Array.isArray(steps)) {
+    steps = [steps];
+  }
 
-	if (!steps.length) {
-	    return false;
-	}
+  if (!steps.length) {
+    return false;
+  }
 
-	this.setState(function(currentState) {
-	    currentState.steps = currentState.steps.concat(this.joyride.parseSteps(steps));
-	    return currentState;
-	});
+  this.setState(function(currentState) {
+    currentState.steps = currentState.steps.concat(this.joyride.parseSteps(steps));
+    return currentState;
+  });
 }
 
 addTooltip: function(data) {
-	this.joyride.addTooltip(data);
+  this.joyride.addTooltip(data);
 }
 ```
 
@@ -84,24 +84,24 @@ When your component is mounted or his child components, just add steps.
 
 ```javascript
 componentDidMount: function () {
-	this.addSteps({...}); // or this.props.addSteps({...}); in your child components
+  this.addSteps({...}); // or this.props.addSteps({...}); in your child components
 }
 ...   
 render: function () {
-	return (
-	  <div>
-		  <Joyride
-		  	ref="joyride"
-		  	steps={this.state.steps}
-		  	run={this.state.steps.length} //or some other trigger to start the Joyride
-		  	...
-		  />
-		  <ChildComponent
-		  	addSteps={this.addSteps}
-		  	addTooltip={this.addTooltip}
-		  />
-		</div>
-	);
+  return (
+    <div>
+      <Joyride
+        ref="joyride"
+        steps={this.state.steps}
+        run={this.state.steps.length} //or some other trigger to start the Joyride
+        ...
+      />
+      <ChildComponent
+        addSteps={this.addSteps}
+        addTooltip={this.addTooltip}
+      />
+    </div>
+  );
 }
 ```
 
@@ -166,13 +166,13 @@ Example:
 
 ```javascript
 <Joyride
-	ref="joyride"
-	steps={this.state.steps}
-	run={this.state.steps.length}
-	debug={true}
-	type="single"
-	callback={this.callback}
-	...
+  ref="joyride"
+  steps={this.state.steps}
+  run={this.state.steps.length}
+  debug={true}
+  type="single"
+  callback={this.callback}
+  ...
 />
 ```
 
@@ -213,15 +213,15 @@ Retrieve the current progress of your tour. The object returned looks like this:
 
 ```javascript
 {
-	index: 2,
-	percentageComplete: 50,
-	step: {
-		title: "...",
-		text: "...",
-		selector: "...",
-		position: "...",
-		...
-	}
+  index: 2,
+  percentageComplete: 50,
+  step: {
+    title: "...",
+    text: "...",
+    selector: "...",
+    position: "...",
+    ...
+  }
 }}
 ```
 
@@ -279,30 +279,30 @@ Example:
     position: 'bottom-left',
     type: 'hover',
     style: {
-		backgroundColor: 'rgba(0, 0, 0, 0.8)',
-		borderRadius: '0',
-		color: '#fff',
-		mainColor: '#ff4456',
-		textAlign: 'center',
-		width: '29rem',
-		beacon: {
-			offsetX: 10,
-			offsetY: 10,
-			inner: '#000',
-			outer: '#000'
-		},
-		button: {
-			display: 'none'
-			// or any style attribute
-		},
-		skip: {
-			color: '#f04'
-		},
-		hole: {
-			backgroundColor: 'RGBA(201, 23, 33, 0.2)',
-		}
-		...
-	},
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    borderRadius: '0',
+    color: '#fff',
+    mainColor: '#ff4456',
+    textAlign: 'center',
+    width: '29rem',
+    beacon: {
+      offsetX: 10,
+      offsetY: 10,
+      inner: '#000',
+      outer: '#000'
+    },
+    button: {
+      display: 'none'
+      // or any style attribute
+    },
+    skip: {
+      color: '#f04'
+    },
+    hole: {
+      backgroundColor: 'RGBA(201, 23, 33, 0.2)',
+    }
+    ...
+  },
     // custom params...
     name: 'my-first-step',
     parent: 'MyComponentName'


### PR DESCRIPTION
This converts the badge links at the top of the readme to markdown links, which do not clutter up the file as much.  Also, my editor (Atom) was not syntax highlighting correctly before this change.

It also removes some trailing spaces and converts tab indentaions to two-spaces.