### PR TITLE
Do not require steps to contain `text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ var steps = this.joyride.parseSteps({
 There are a few usable options but you can pass custom parameters.
 
 - `title`: The title of the tooltip
-- `text`: The tooltip's body text **(required)**
+- `text`: The tooltip's body text
 - `selector`: The target DOM selector of your feature **(required)**
 - `position`: Relative position of you beacon and tooltip. It can be one of these:`top`, `top-left`, `top-right`, `bottom`, `bottom-left`, `bottom-right`, `right` and `left`. This defaults to `top`.
 - `type`: The event type that trigger the tooltip: `click` or `hover`. Defaults to `click`

--- a/lib/scripts/Joyride.js
+++ b/lib/scripts/Joyride.js
@@ -48,7 +48,7 @@ if(shouldRestart&&isRunning===shouldRestart&&index===0){this.forceUpdate();}this
    * @returns {boolean} - True if the step is valid, false otherwise
    */},{key:'checkStepValidity',value:function checkStepValidity(step){var _this3=this;// Check that the step is the proper type
 if(!step||(typeof step==='undefined'?'undefined':_typeof(step))!=='object'||Array.isArray(step)){(0,_utils.logger)({type:'joyride:checkStepValidity',msg:'Did not provide a step object.',warn:true,debug:this.props.debug});return false;}// Check that all required step fields are present
-var requiredFields=['selector','text'];var hasRequiredField=function hasRequiredField(requiredField){var hasField=Boolean(step[requiredField]);if(!hasField){(0,_utils.logger)({type:'joyride:checkStepValidity',msg:['Provided a step without the required '+requiredField+' property.','Step:',step],warn:true,debug:_this3.props.debug});}return hasField;};return requiredFields.every(hasRequiredField);}/**
+var requiredFields=['selector'];var hasRequiredField=function hasRequiredField(requiredField){var hasField=Boolean(step[requiredField]);if(!hasField){(0,_utils.logger)({type:'joyride:checkStepValidity',msg:['Provided a step without the required '+requiredField+' property.','Step:',step],warn:true,debug:_this3.props.debug});}return hasField;};return requiredFields.every(hasRequiredField);}/**
    * Check one or more steps are valid
    *
    * @param {Object|Array} steps - A step object or array of step objects

--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -552,7 +552,7 @@ class Joyride extends React.Component {
     }
 
     // Check that all required step fields are present
-    const requiredFields = ['selector', 'text'];
+    const requiredFields = ['selector'];
     const hasRequiredField = (requiredField) => {
       const hasField = Boolean(step[requiredField]);
       if (!hasField) {


### PR DESCRIPTION
I don't see a good reason to enforce this requirement.  If someone wants a tooltip with just a title, why not let them?  The library will work regardless.  I think the only thing that's actually _required_ is a selector.