### PR TITLE
Always allow pointer-events in tooltips

### DIFF
--- a/lib/styles/react-joyride-compiled.css
+++ b/lib/styles/react-joyride-compiled.css
@@ -53,6 +53,7 @@
     box-shadow: 0 0 999px 9999px rgba(0, 0, 0, 0.5), 0 0 15px rgba(0, 0, 0, 0.5); }
 
 .joyride-tooltip {
+  pointer-events: auto;
   background-color: #fff;
   border-radius: 4px;
   color: #555;

--- a/lib/styles/react-joyride.scss
+++ b/lib/styles/react-joyride.scss
@@ -120,6 +120,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
   }
 
   &-tooltip {
+    pointer-events: auto;
     background-color: $joyride-tooltip-bg-color;
     border-radius: $joyride-tooltip-border-radius;
     color: $joyride-tooltip-color;

--- a/src/styles/react-joyride.scss
+++ b/src/styles/react-joyride.scss
@@ -120,6 +120,7 @@ $joyride-tooltip-arrow-scale: ($joyride-tooltip-arrow-size / ($joyride-tooltip-a
   }
 
   &-tooltip {
+    pointer-events: auto;
     background-color: $joyride-tooltip-bg-color;
     border-radius: $joyride-tooltip-border-radius;
     color: $joyride-tooltip-color;


### PR DESCRIPTION
Fixes #182 

## Description

This adds `pointer-events: auto` to the joyride tooltips.  That's needed because the tooltip's parent is the joyride overlay, which in some cases can have `pointer-events: none`, specifically when the mouse is inside the overlay hole.  Setting that property on the overlay allows mouse clicks to pass through it, but unfortunately was also preventing tooltips inside the overlay from capturing clicks either.  This PR fixes that.

## To test

In the `test/demo/App.jsx`, change the first step to have:

```
selector: '.hero',
position: 'top',
```

Start the demo, open the tooltip, and you should be able to click the button.  Without these changes, you cannot.