### PR TITLE
Respect `autoStart` prop when resetting

### DIFF
--- a/lib/scripts/Joyride.js
+++ b/lib/scripts/Joyride.js
@@ -25,7 +25,7 @@ if(shouldRedraw&&step){this.calcPlacement();}if(isRunning&&scrollToSteps&&should
    * Reset Tour
    *
    * @param {boolean} [restart] - Starts the new tour right away
-   */},{key:'reset',value:function reset(restart){var _state6=this.state,index=_state6.index,isRunning=_state6.isRunning;var shouldRestart=restart===true;var newState=JSON.parse(JSON.stringify(defaultState));newState.isRunning=shouldRestart;(0,_utils.logger)({type:'joyride:reset',msg:['restart:',shouldRestart],debug:this.props.debug});// Force a re-render if necessary
+   */},{key:'reset',value:function reset(restart){var _state6=this.state,index=_state6.index,isRunning=_state6.isRunning;var shouldRestart=restart===true;var newState=_extends({},defaultState,{isRunning:shouldRestart,shouldRenderTooltip:this.props.autoStart});(0,_utils.logger)({type:'joyride:reset',msg:['restart:',shouldRestart],debug:this.props.debug});// Force a re-render if necessary
 if(shouldRestart&&isRunning===shouldRestart&&index===0){this.forceUpdate();}this.setState(newState);}/**
    * Retrieve the current progress of your tour
    *

--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -435,8 +435,11 @@ class Joyride extends React.Component {
     const { index, isRunning } = this.state;
     const shouldRestart = restart === true;
 
-    const newState = JSON.parse(JSON.stringify(defaultState));
-    newState.isRunning = shouldRestart;
+    const newState = {
+      ...defaultState,
+      isRunning: shouldRestart,
+      shouldRenderTooltip: this.props.autoStart,
+    };
 
     logger({
       type: 'joyride:reset',


### PR DESCRIPTION
Fixes #188 

## Description

This fixes a bug whereby the joyride would not show a tooltip immediately without a beacon when calling `joyride.reset(true)`, even when the `autoRun` prop was set to `true`.

## To Test

In the demo, make the following changes:

- In `handleNextButtonClick`, change `this.joyride.next()` to `this.joyride.reset(true)`
- Set the prop `autoRun` to `true` on the Joyride

Then, verify that the bug exists without this PR by clicking the `advance` button in the second step and noticing that the beacon of the first step is shown.

With the changes in this PR, verify that the tooltip is shown immediately.