### PR TITLE
Fixes calculation of mouse in tutorial hole, for fixed DOM elements

### DIFF
--- a/src/scripts/Tooltip.jsx
+++ b/src/scripts/Tooltip.jsx
@@ -356,7 +356,7 @@ export default class JoyrideTooltip extends React.Component {
   handleMouseMove = (e) => {
     const event = e || window.e;
     const hole = this.state.styles.hole;
-    const offsetY = hole.position == 'fixed' ? event.clientY : event.pageY
+    const offsetY = hole.position === 'fixed' ? event.clientY : event.pageY;
     const inHoleHeight = (offsetY >= hole.top && offsetY <= hole.top + hole.height);
     const inHoleWidth = (event.pageX >= hole.left && event.pageX <= hole.left + hole.width);
     const inHole = inHoleWidth && inHoleHeight;

--- a/src/scripts/Tooltip.jsx
+++ b/src/scripts/Tooltip.jsx
@@ -356,7 +356,8 @@ export default class JoyrideTooltip extends React.Component {
   handleMouseMove = (e) => {
     const event = e || window.e;
     const hole = this.state.styles.hole;
-    const inHoleHeight = (event.pageY >= hole.top && event.pageY <= hole.top + hole.height);
+    const offsetY = hole.position == 'fixed' ? event.clientY : event.pageY
+    const inHoleHeight = (offsetY >= hole.top && offsetY <= hole.top + hole.height);
     const inHoleWidth = (event.pageX >= hole.left && event.pageX <= hole.left + hole.width);
     const inHole = inHoleWidth && inHoleHeight;
     if (inHole && !this.state.mouseOverHole) {

--- a/src/scripts/Tooltip.jsx
+++ b/src/scripts/Tooltip.jsx
@@ -357,8 +357,9 @@ export default class JoyrideTooltip extends React.Component {
     const event = e || window.e;
     const hole = this.state.styles.hole;
     const offsetY = hole.position === 'fixed' ? event.clientY : event.pageY;
+    const offsetX = hole.position === 'fixed' ? event.clientX : event.pageX;
     const inHoleHeight = (offsetY >= hole.top && offsetY <= hole.top + hole.height);
-    const inHoleWidth = (event.pageX >= hole.left && event.pageX <= hole.left + hole.width);
+    const inHoleWidth = (offsetX >= hole.left && offsetX <= hole.left + hole.width);
     const inHole = inHoleWidth && inHoleHeight;
     if (inHole && !this.state.mouseOverHole) {
       this.setState({ mouseOverHole: true });


### PR DESCRIPTION
There was a problem with calculation of mouse position inside or outside tutorial hole. 
In case we set a step on **position:fixed element,** if we scroll in page, because the mouse position was based on event.pageY and not event.clientY, the pointer-events was "auto" instead of "none" when I moved my mouse on my fixed element.
So I fixed the problem with usage of event.clientY or event.pageY depending on isFixed.