### PR TITLE
state now initializes w/ props

### DIFF
--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -9,9 +9,9 @@ import Tooltip from 'scripts/Tooltip';
 
 import 'styles/react-joyride.scss';
 
-const defaultState = {
+const getDefaultState = props => ({
   action: '',
-  index: 0,
+  index: props.stepIndex || 0,
   isRunning: false,
   isTourSkipped: false,
   shouldRedraw: true,
@@ -20,7 +20,7 @@ const defaultState = {
   standaloneData: false, // The standalone tooltip data
   xPos: -1000,
   yPos: -1000
-};
+});
 
 const callbackTypes = {
   STEP_BEFORE: 'step:before',
@@ -48,7 +48,7 @@ class Joyride extends React.Component {
     super(props);
     autobind(this);
 
-    this.state = { ...defaultState };
+    this.state = { ...getDefaultState(props) };
 
     this.listeners = {
       tooltips: {}


### PR DESCRIPTION
in response to #223  

As-written state was just a static object, so it couldn't initialize using the `stepIndex` prop. 

This change is pretty simple &  tests still pass locally