### PR TITLE
Remove use of string template

### DIFF
--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -1186,7 +1186,7 @@ class Joyride extends React.Component {
                 next = (<span>{locale.next}</span>);
               }
 
-              buttons.primary = (<span>{next} <span>{`${(index + 1)}/${steps.length}`}</span></span>);
+              buttons.primary = (<span>{next} <span>{index + 1}/{steps.length}}</span></span>);
             }
             else {
               buttons.primary = locale.next;

--- a/src/scripts/Joyride.jsx
+++ b/src/scripts/Joyride.jsx
@@ -1186,7 +1186,7 @@ class Joyride extends React.Component {
                 next = (<span>{locale.next}</span>);
               }
 
-              buttons.primary = (<span>{next} <span>{index + 1}/{steps.length}}</span></span>);
+              buttons.primary = (<span>{next} <span>{index + 1}/{steps.length}</span></span>);
             }
             else {
               buttons.primary = locale.next;


### PR DESCRIPTION
`{`${(index + 1)}/${steps.length}`}` this can be {index + 1}/{steps.length}