### PR TITLE
fix(package.json): remove engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,5 @@
     "precommit": "node config/tools commits && npm run lint && npm run lint:styles && npm test",
     "prepublish": "npm run build",
     "postmerge": "node config/tools update && npm update"
-  },
-  "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=3.0.0"
   }
 }


### PR DESCRIPTION
Fixes #255 (see also #131)

Per the fixed issue, the `engines` field is not required since this module runs in the browser only. 
 Specifying an engines field prevents the module from being installed with `yarn` on incompatible versions of Node, unnecessarily.

The field is sometimes used by other build/deploy tools, however, scanning the repo I did see any dependencies on the field.  Unless I've overlooked something, removing it should be entirely safe and fix installs for `yarn` users.