### PR TITLE
Performance: reuse result of #getScrollTop()

### DIFF
--- a/src/scripts/index.jsx
+++ b/src/scripts/index.jsx
@@ -383,7 +383,7 @@ class Joyride extends React.Component {
     }
 
     if (isRunning && scrollToSteps && shouldScroll && scrollTop >= 0) {
-      scroll.top(getRootEl(), this.getScrollTop());
+      scroll.top(getRootEl(), scrollTop);
     }
 
     if (steps.length && (!isRunning && shouldRun && !standaloneData)) {


### PR DESCRIPTION
In the if-condition, the result is used while in the if-body it is re-evaluated.

**Important:** Please verify that #calcPlacement() does not affect #getScrollTop(). I have tested it and in my cases it works fine.