### PR TITLE
Export callbackTypes

### DIFF
--- a/src/scripts/index.jsx
+++ b/src/scripts/index.jsx
@@ -20,7 +20,7 @@ const defaultState = {
   yPos: -1000
 };
 
-const callbackTypes = {
+export const callbackTypes = {
   STEP_BEFORE: 'step:before',
   BEACON_BEFORE: 'beacon:before',
   BEACON_TRIGGER: 'beacon:trigger',


### PR DESCRIPTION
It's great that the codebase is using these nice constants instead of hard coding strings.
```javascript
const callbackTypes = {
  STEP_BEFORE: 'step:before',
  BEACON_BEFORE: 'beacon:before',
  BEACON_TRIGGER: 'beacon:trigger',
  TOOLTIP_BEFORE: 'tooltip:before',
  STEP_AFTER: 'step:after',
  STANDALONE_BEFORE: 'standalone:before',
  STANDALONE_AFTER: 'standalone:after',
  OVERLAY: 'overlay:click',
  HOLE: 'hole:click',
  FINISHED: 'finished',
  TARGET_NOT_FOUND: 'error:target_not_found'
};
```
It'd be really nice if these constants could be exposed to anyone using React Joyride, particularly in their callback function to Joyride:
```javascript
import { callbackTypes } from 'react-joyride';

function joyrideCallback(data) {
  if (data.type === callbackTypes.STEP_BEFORE) {
    // Do stuff
  }
}
```
This pull request exports the `callbackTypes` object so it's available to anyone using the library.