### PR TITLE
Enable ref selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ There are some usable options but you can pass custom parameters.
 
 - `title`: The tooltip's title.
 - `text`: The tooltip's content. It can be plain text, html or a React component.
-- `selector`: The target DOM selector of your feature **(required)**
+- `selector`: The target DOM selector or element reference of your feature **(required)**
 - `position`: Relative position of you beacon and tooltip. It can be one of these:`top`, `top-left`, `top-right`, `bottom`, `bottom-left`, `bottom-right`, `right` and `left`. This defaults to `top`.
 - `type`: The event type that trigger the tooltip: `click` or `hover`. Defaults to `click`
 - `isFixed`: If `true`, the tooltip will remain in a fixed position within the viewport. Defaults to `false`.

--- a/src/scripts/Tooltip.jsx
+++ b/src/scripts/Tooltip.jsx
@@ -24,8 +24,8 @@ export default class JoyrideTooltip extends React.Component {
       'bottom', 'bottom-left', 'bottom-right',
       'right', 'left',
     ]).isRequired,
-    // sanitized selector string
-    selector: PropTypes.string.isRequired,
+    // sanitized selector string or dom reference
+    selector: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
     showOverlay: PropTypes.bool.isRequired,
     standalone: PropTypes.bool,
     step: PropTypes.object.isRequired,

--- a/src/scripts/index.jsx
+++ b/src/scripts/index.jsx
@@ -583,9 +583,10 @@ class Joyride extends React.Component {
       debug: this.props.debug,
     });
 
-    // TODO: change da things
     const key = data.trigger || sanitizeSelector(data.selector);
-    const el = document.querySelector(key);
+    const el = (isNode(key) || isElement(key))
+      ? key
+      : document.querySelector(key);
 
     if (!el) {
       return;

--- a/src/scripts/index.jsx
+++ b/src/scripts/index.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import scroll from 'scroll';
 import nested from 'nested-property';
-import { getRootEl, getOffsetBoundingClientRect, logger, sanitizeSelector, getDocHeight } from './utils';
+import {
+  getRootEl, getOffsetBoundingClientRect, logger, sanitizeSelector,
+  getDocHeight, isNode, isElement
+} from './utils';
 
 import Beacon from './Beacon';
 import Tooltip from './Tooltip';
@@ -127,7 +130,7 @@ class Joyride extends React.Component {
     });
 
     const stepsAreValid = this.checkStepsValidity(steps);
-    if (steps && stepsAreValid && run) {
+    if (steps && stepsAreValid && run && !this.stepsSelectorUnmounted(steps)) {
       this.start(autoStart);
     }
 
@@ -180,11 +183,15 @@ class Joyride extends React.Component {
 
     if (stepsChanged && this.checkStepsValidity(nextProps.steps)) {
       // Removed all steps, so reset
-      if (!nextProps.steps || !nextProps.steps.length) {
+      if (!nextProps.steps || !nextProps.steps.length || this.stepsSelectorChanged(steps, nextProps.steps)) {
         this.reset();
       }
       // Start the joyride if steps were added for the first time, and run prop is true
-      else if (!steps.length && nextProps.run) {
+      else if (!steps.length && nextProps.run && !this.stepsSelectorUnmounted(steps)) {
+        shouldStart = true;
+      }
+      // Start the joyride if a selector was missing and is now present
+      if (nextProps.run && this.stepsSelectorUnmounted(steps) && !this.stepsSelectorUnmounted(nextProps.steps)) {
         shouldStart = true;
       }
     }
@@ -416,6 +423,13 @@ class Joyride extends React.Component {
     }
   }
 
+  stepsSelectorChanged = (currentSteps, nextSteps) => currentSteps.find((step, index) => {
+    if (!nextSteps[index]) return true;
+    return nextSteps[index].selector !== step.selector;
+  });
+
+  stepsSelectorUnmounted = currentSteps => currentSteps.find(step => step.selector === '{not-mounted}');
+
   /**
    * Starts the tour
    *
@@ -569,6 +583,7 @@ class Joyride extends React.Component {
       debug: this.props.debug,
     });
 
+    // TODO: change da things
     const key = data.trigger || sanitizeSelector(data.selector);
     const el = document.querySelector(key);
 
@@ -675,8 +690,9 @@ class Joyride extends React.Component {
     if (!isValidStep) {
       return null;
     }
-
-    const el = document.querySelector(sanitizeSelector(step.selector));
+    const el = (isNode(step.selector) || isElement(step.selector))
+      ? step.selector
+      : document.querySelector(sanitizeSelector(step.selector));
 
     if (!el) {
       logger({

--- a/src/scripts/index.jsx
+++ b/src/scripts/index.jsx
@@ -428,7 +428,7 @@ class Joyride extends React.Component {
     return nextSteps[index].selector !== step.selector;
   });
 
-  stepsSelectorUnmounted = currentSteps => currentSteps.find(step => step.selector === '{not-mounted}');
+  stepsSelectorUnmounted = currentSteps => currentSteps.find(step => sanitizeSelector(step.selector) === '{not-mounted}');
 
   /**
    * Starts the tour
@@ -672,7 +672,7 @@ class Joyride extends React.Component {
       return this.checkStepValidity(steps);
     }
     else if (steps.length > 0) {
-      return steps.every(this.checkStepValidity);
+      return steps.every(step => this.checkStepValidity({ ...step, selector: sanitizeSelector(step.selector) }));
     }
 
     return false;

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -6,7 +6,7 @@
  * @param   {string|Object} o - The selector provided in a step object
  * @returns {boolean}
  */
-function isNode(o) {
+export function isNode(o) {
   return (
     typeof Node === 'object' ? o instanceof Node :
       o && typeof o === 'object' && typeof o.nodeType === 'number' && typeof o.nodeName === 'string'
@@ -19,7 +19,7 @@ function isNode(o) {
  * @param   {string|Object} o - The selector provided in a step object
  * @returns {boolean}
  */
-function isElement(o) {
+export function isElement(o) {
   return (
     typeof HTMLElement === 'object' ? o instanceof HTMLElement :
       o && typeof o === 'object' && o !== null && o.nodeType === 1 && typeof o.nodeName === 'string'

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -123,6 +123,20 @@ export function logger({ type = 'joyride', msg, warn = false, debug = false }) {
   }
 }
 
+function sanitizeObjectSelector(selector) {
+  if (isNode(selector) || isElement(selector)) return selector;
+
+  if (selector.dataset) {
+    if (selector.dataset.reactid) {
+      console.warn('Deprecation warning: React 15.0 removed reactid. Update your code.'); //eslint-disable-line no-console
+      return `[data-reactid="${selector.dataset.reactid}"]`;
+    }
+    // eslint-disable-next-line no-console
+    console.error('Unsupported error: React 15.0+ doesn’t write reactid to the DOM anymore, please use a plain class in your step.', selector);
+  }
+  return selector.className ? `.${selector.className.replace(' ', '.')}` : selector;
+}
+
 /**
  * Check for deprecated selector styles, return stringified, safer versions
  *
@@ -131,21 +145,7 @@ export function logger({ type = 'joyride', msg, warn = false, debug = false }) {
  */
 export function sanitizeSelector(selector) {
   if (selector == null) return '{not-mounted}';
-  if (isNode(selector) || isElement(selector)) return selector;
-
-  if (selector.dataset && selector.dataset.reactid) {
-    console.warn('Deprecation warning: React 15.0 removed reactid. Update your code.'); //eslint-disable-line no-console
-    return `[data-reactid="${selector.dataset.reactid}"]`;
-  }
-  else if (selector.dataset) {
-    console.error('Unsupported error: React 15.0+ doesn’t write reactid to the DOM anymore, please use a plain class in your step.', selector); //eslint-disable-line no-console
-
-    /* istanbul ignore else */
-    if (selector.className) {
-      return `.${selector.className.replace(' ', '.')}`;
-    }
-  }
-  return selector;
+  return typeof selector === 'string' ? selector : sanitizeObjectSelector(selector);
 }
 
 /**

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -1,6 +1,32 @@
 /*eslint-disable no-nested-ternary */
 
 /**
+ * Returns true if it is a DOM node
+ *
+ * @param   {string|Object} o - The selector provided in a step object
+ * @returns {boolean}
+ */
+function isNode(o) {
+  return (
+    typeof Node === 'object' ? o instanceof Node :
+      o && typeof o === 'object' && typeof o.nodeType === 'number' && typeof o.nodeName === 'string'
+  );
+}
+
+/**
+ * Returns true if it is a DOM element
+ *
+ * @param   {string|Object} o - The selector provided in a step object
+ * @returns {boolean}
+ */
+function isElement(o) {
+  return (
+    typeof HTMLElement === 'object' ? o instanceof HTMLElement :
+      o && typeof o === 'object' && o !== null && o.nodeType === 1 && typeof o.nodeName === 'string'
+  );
+}
+
+/**
  * Convert hex to RGB
  *
  * @param {string} hex
@@ -104,6 +130,8 @@ export function logger({ type = 'joyride', msg, warn = false, debug = false }) {
  * @returns {string}                   A cleaned-up selector string
  */
 export function sanitizeSelector(selector) {
+  if (isNode(selector) || isElement(selector)) return selector;
+
   if (selector.dataset && selector.dataset.reactid) {
     console.warn('Deprecation warning: React 15.0 removed reactid. Update your code.'); //eslint-disable-line no-console
     return `[data-reactid="${selector.dataset.reactid}"]`;

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -130,6 +130,7 @@ export function logger({ type = 'joyride', msg, warn = false, debug = false }) {
  * @returns {string}                   A cleaned-up selector string
  */
 export function sanitizeSelector(selector) {
+  if (selector == null) return '{not-mounted}';
   if (isNode(selector) || isElement(selector)) return selector;
 
   if (selector.dataset && selector.dataset.reactid) {

--- a/test/demo.spec.js
+++ b/test/demo.spec.js
@@ -22,13 +22,13 @@ function setup(ownProps = props) {
 
 function setupWithRefs(ownProps = {}) {
   class RefDemo extends React.Component {
-    state = { selectorRef: null, joyride: true };
+    state = { selectorRef: null };
 
+    // this is so we can access the references from the test later on
     componentDidMount() {
       this.setState(prevState => ({
         ...prevState,
         selectorRef: this.selectorRef,
-        joyride: true
       }));
     }
 
@@ -39,15 +39,16 @@ function setupWithRefs(ownProps = {}) {
         steps: [
           {
             text: 'Tooltip Text.',
-            selector: this.state.selectorRef || '{not-mounted}',
+            selector: this.selectorRef,
           },
         ],
-        type: 'single'
+        type: 'single',
+        ...ownProps,
       };
 
       return (
         <div className="demo">
-          {this.state.joyride && <Joyride {...joyrideProps} />}
+          <Joyride {...joyrideProps} />
           <div
             ref={c => { this.selectorRef = c; }}
             className="mission">

--- a/test/demo.spec.js
+++ b/test/demo.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import Joyride from '../src/scripts';
 
 import Demo from '../demo/src/App';
 
@@ -17,6 +18,46 @@ function setup(ownProps = props) {
     <Demo joyride={ownProps} />,
     { attachTo: document.getElementById('react') }
   );
+}
+
+function setupWithRefs(ownProps = {}) {
+  class RefDemo extends React.Component {
+    state = { selectorRef: null, joyride: true };
+
+    componentDidMount() {
+      this.setState(prevState => ({
+        ...prevState,
+        selectorRef: this.selectorRef,
+        joyride: true
+      }));
+    }
+
+    render() {
+      const joyrideProps = {
+        autoStart: true,
+        run: true,
+        steps: [
+          {
+            text: 'Tooltip Text.',
+            selector: this.state.selectorRef || '{not-mounted}',
+          },
+        ],
+        type: 'single'
+      };
+
+      return (
+        <div className="demo">
+          {this.state.joyride && <Joyride {...joyrideProps} />}
+          <div
+            ref={c => { this.selectorRef = c; }}
+            className="mission">
+            Tour Anchor
+          </div>
+        </div>
+      );
+    }
+  }
+  return mount(<RefDemo />, { attachTo: document.getElementById('react') });
 }
 
 describe('Joyride', () => {
@@ -195,5 +236,16 @@ describe('Joyride', () => {
       expect(wrapper.find('JoyrideTooltip').length).toBe(1);
       expect(wrapper.find('.joyride-tooltip').html()).toMatchSnapshot();
     });
+  });
+
+  it('tour with ref as selector', () => {
+    const customWrapper = setupWithRefs();
+    const stateRef = customWrapper.state('selectorRef');
+    const toolTipWrapper = customWrapper.find('.joyride-tooltip');
+
+    expect(stateRef).not.toBeUndefined();
+    expect(toolTipWrapper.length).toBe(1);
+
+    customWrapper.detach();
   });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -65,5 +65,10 @@ describe('utils', () => {
       .toBe('Unsupported error: React 15.0+ doesn’t write reactid to the DOM anymore, please use a plain class in your step.');
 
     expect(sanitizeSelector('.classy')).toEqual('.classy');
+
+    expect(sanitizeSelector(undefined)).toEqual('{not-mounted}');
+
+    const htmlElement = document.createElement('div');
+    expect(sanitizeSelector(htmlElement)).toEqual(htmlElement);
   });
 });


### PR DESCRIPTION
Adresses #311 

The `sanitizeSelector` helper now checks whether the passed value is a DOM element. If so, it gets passed through to joyride. Joyride only uses `document.querySelector` if the value of the selector is not a DOM element.

This change will also make it possible to pass a falsy selector for a tour step. If any selectors are falsy, the tour will not start.
This behavior is necessary because it is possible for references to be undefined (because the elements haven't been rendered) before steps are passed to joyride.