### PR TITLE
Use class method to set ref

### DIFF
--- a/app/scripts/containers/App.jsx
+++ b/app/scripts/containers/App.jsx
@@ -96,6 +96,10 @@ class App extends React.Component {
 
     this.setState(state);
   }
+  
+  setJoyrideRef(c) {
+    this.joyride = c;
+  }
 
   render() {
     const {
@@ -113,7 +117,7 @@ class App extends React.Component {
       html = (
         <div>
           <Joyride
-            ref={c => (this.joyride = c)}
+            ref={this.setJoyrideRef}
             callback={this.callback}
             debug={false}
             disableOverlay={selector === '.card-tickets'}


### PR DESCRIPTION
React is seeing a new function for the ref callback each time a render is performed. This leads to unnecessary calls.

This PR moves the ref callback into a class method so a single function reference can be attached. This way, React will receive the same method in each render and ignore calling it except when the ref actually unmounts.