### PR TITLE
fix links to docs pages from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ export class App extends React.Component {
 
 ## Documentation
 
-* [Props](/docs/Props.md)
-* [Step](/docs/Step.md)
-* [Styling](/docs/Styling.md)
-* [Callback](/docs/Callback.md)
-* [Constants](/docs/Constants.md)
+* [Props](/docs/props.md)
+* [Step](/docs/step.md)
+* [Styling](/docs/styling.md)
+* [Callback](/docs/callback.md)
+* [Constants](/docs/constants.md)
 
 
 


### PR DESCRIPTION
The links on the readme of v2 currently don't work for me because the casing doesn't match