### PR TITLE
Update overlay render on browser resize

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "newline-per-chained-call": ["warn", { "ignoreChainWithDepth": 5 }],
     "no-case-declarations": "warn",
     "no-confusing-arrow": ["warn", { "allowParens": true }],
+    "no-mixed-operators": 0,
     "no-mixed-spaces-and-tabs": ["warn", "smart-tabs"],
     "no-multi-spaces": [
       "warn", {


### PR DESCRIPTION
See #377 

Current implementation uses a throttle approach taken from MDN: see https://developer.mozilla.org/en-US/docs/Web/Events/resize#requestAnimationFrame_customEvent which requires a polyfill on IE 11... including the polyfill is something you'd like to do in this package or... ?

Also: it uses a call to `forceUpdate` (if you prefer a different approach, let me know)