### PR TITLE
Fix callback parameter name in getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export class App extends React.Component {
     this.setState({ run: true });
   }
 
-  callback = (tour) => {
+  callback = (data) => {
     const { action, index, type } = data;
   };
 


### PR DESCRIPTION
Fixes callback parameter name in the README.md
getting started code.