### PR TITLE
missing polyfills and spotlight style change

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,6 +18,7 @@
       "plugins": [
         "array-includes",
         "external-helpers",
+        "transform-runtime",
         "transform-flow-strip-types",
         "transform-node-env-inline"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,12 +3604,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3624,17 +3626,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3751,7 +3756,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3763,6 +3769,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3777,6 +3784,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3784,12 +3792,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3808,6 +3818,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3888,7 +3899,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3900,6 +3912,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4021,6 +4034,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ export default {
   plugins: [
     babel({
       exclude: 'node_modules/**',
+      runtimeHelpers: true,
     }),
     commonjs(),
   ],

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -151,7 +151,6 @@ export default class Overlay extends React.Component {
       pointerEvents: spotlightClicks ? 'none' : 'auto',
       position: isFixedTarget ? 'fixed' : 'absolute',
       top,
-      transition: 'opacity 0.2s',
       width: Math.round(elementRect.width + (spotlightPadding * 2)),
     };
   }

--- a/src/styles.js
+++ b/src/styles.js
@@ -26,6 +26,7 @@ const buttonReset = {
 const spotlight = {
   borderRadius: 4,
   position: 'absolute',
+  transition: 'opacity 0.2s',
 };
 
 export default function getStyles(stepStyles) {


### PR DESCRIPTION
These are 2 straightforward changes.
* the first is simply changing babel and rollup config to install appropriate polyfills (I have found Map, Set and Promise). This should make this library work on older browsers
* the second is moving the spotlight "transition" style in a place where I can override it

The reason around the second is that allows me to implement the spotlight with a technique that work in old browsers too:

```
  overlay: {
    cursor: 'default',
    mixBlendMode: 'unset',
    backgroundColor: 'transparent'
  },
  spotlight: {
    backgroundColor: 'transparent',
    outline: '100vmax rgba(0, 0, 0, 0.5) solid',
    borderRadius: 0,
    transition: 'unset'
  },
```

To be honest, I think this would also be a safer default than using mix-blend-style. But this would be another PR