### PR TITLE
WAI-ARIA screen reader support

### DIFF
--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -77,6 +77,7 @@ export default class JoyrideStep extends React.Component {
   componentDidMount() {
     const { debug, lifecycle } = this.props;
 
+    this.focus();
     log({
       title: `step:${lifecycle}`,
       data: [
@@ -144,6 +145,7 @@ export default class JoyrideStep extends React.Component {
     }
 
     if (changed('index')) {
+      this.focus();
       log({
         title: `step:${lifecycle}`,
         data: [
@@ -234,6 +236,10 @@ export default class JoyrideStep extends React.Component {
     const { step, lifecycle } = this.props;
 
     return !!(hideBeacon(step) || lifecycle === LIFECYCLE.TOOLTIP);
+  }
+
+  focus = (e) => {
+    this.tooltip.focus();
   }
 
   render() {

--- a/src/components/Tooltip/Container.js
+++ b/src/components/Tooltip/Container.js
@@ -82,10 +82,11 @@ const JoyrideTooltipContainer = ({
       tabIndex={-1}
       role="region"
       aria-live="polite"
+      aria-label={title}
     >
       <div style={styles.tooltipContainer}>
         {output.close}
-        {title && (<h4 style={styles.tooltipTitle}>{title}</h4>)}
+        {title && (<h4 style={styles.tooltipTitle} aria-hidden>{title}</h4>)}
         {!!content && (
           <div style={styles.tooltipContent}>
             {content}

--- a/src/components/Tooltip/Container.js
+++ b/src/components/Tooltip/Container.js
@@ -79,6 +79,9 @@ const JoyrideTooltipContainer = ({
       className="react-joyride__tooltip"
       ref={setTooltipRef}
       style={styles.tooltip}
+      tabIndex={-1}
+      role="region"
+      aria-live="polite"
     >
       <div style={styles.tooltipContainer}>
         {output.close}

--- a/src/components/Tooltip/Container.js
+++ b/src/components/Tooltip/Container.js
@@ -82,11 +82,18 @@ const JoyrideTooltipContainer = ({
       tabIndex={-1}
       role="region"
       aria-live="polite"
-      aria-label={title}
+      aria-label={typeof title === 'string' ? title : undefined}
     >
       <div style={styles.tooltipContainer}>
         {output.close}
-        {title && (<h4 style={styles.tooltipTitle} aria-hidden>{title}</h4>)}
+        {title && (
+          <h4
+            style={styles.tooltipTitle}
+            aria-hidden={typeof title === 'string' ? true : undefined}
+          >
+            {title}
+          </h4>
+        )}
         {!!content && (
           <div style={styles.tooltipContent}>
             {content}


### PR DESCRIPTION
Some users are "visually impared" which means they don't look at the screen while using a website.
Such users use "screen readers" like macOS "Voice Over" or Windows "NVDA".
https://www.youtube.com/watch?v=5R-6WvAihms

Currently this component doesn't work with screen readers.
This pull request is supposed to fix that by using `aria-live` attribute and `.focus()` to tell a screen reader to announce the tooltip text.
This code was previously written for v1.0 and was tested against v1.0.
https://github.com/oseibonsu/react-joyride/commit/80f3a98f59f16761459f5d329d4d77a3a3cd9a0e
In v2.0 you rewrote the component so this code wasn't tested for v2.0 because there's no demo provided in the repo.