### PR TITLE
Body border radius

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=lf

--- a/src/styles.js
+++ b/src/styles.js
@@ -12,6 +12,8 @@ const defaultOptions = {
   zIndex: 100,
 };
 
+const tooltipBorderRadius = 5;
+
 const buttonBase = {
   backgroundColor: 'transparent',
   border: 0,
@@ -28,6 +30,26 @@ const spotlight = {
   borderRadius: 4,
   position: 'absolute',
 };
+
+function getArrowMargin(styles) {
+  const tooltipHasGotBorderRadius = styles.tooltip && styles.tooltip.borderRadius;
+  const arrowHasNotGotMargin = !(
+    styles.floaterStyles &&
+    styles.floaterStyles.arrow &&
+    styles.floaterStyles.arrow.margin
+  );
+
+  if (tooltipHasGotBorderRadius && arrowHasNotGotMargin) {
+    return {
+      floaterStyles: {
+        arrow: {
+          margin: styles.tooltip.borderRadius,
+        },
+      },
+    };
+  }
+  return {};
+}
 
 export default function getStyles(stepStyles = {}) {
   const options = deepmerge(defaultOptions, stepStyles.options || {});
@@ -94,7 +116,7 @@ export default function getStyles(stepStyles = {}) {
     },
     tooltip: {
       backgroundColor: options.backgroundColor,
-      borderRadius: 5,
+      borderRadius: tooltipBorderRadius,
       boxSizing: 'border-box',
       color: options.textColor,
       fontSize: 16,
@@ -173,6 +195,7 @@ export default function getStyles(stepStyles = {}) {
     floaterStyles: {
       arrow: {
         color: options.arrowColor,
+        margin: tooltipBorderRadius,
       },
       options: {
         zIndex: options.zIndex,
@@ -181,5 +204,5 @@ export default function getStyles(stepStyles = {}) {
     options,
   };
 
-  return deepmerge(defaultStyles, stepStyles);
+  return deepmerge.all([defaultStyles, stepStyles, getArrowMargin(stepStyles)]);
 }


### PR DESCRIPTION
Fix for issue when the arrow is clashing with the body border-radius.
The fix is based on the fix in react-floater.
Now in styles object when `tooltip.borderRadius` is set, the same value will be set to `floaterStyles.arrow.margin`, but it won't overwrite user value of arrow margin.