### PR TITLE
Added new prop "spotlightTarget"

### DIFF
--- a/defs/globals.js
+++ b/defs/globals.js
@@ -63,6 +63,7 @@ export interface StepProps {
   showSkipButton?: boolean;
   spotlightClicks?: boolean;
   spotlightPadding?: number;
+  spotlightTarget: string | HTMLElement;
   styles?: Object;
   target: string | HTMLElement;
   title?: ReactNode;

--- a/defs/globals.js
+++ b/defs/globals.js
@@ -63,7 +63,7 @@ export interface StepProps {
   showSkipButton?: boolean;
   spotlightClicks?: boolean;
   spotlightPadding?: number;
-  spotlightTarget: string | HTMLElement;
+  spotlightTarget?: string | HTMLElement;
   styles?: Object;
   target: string | HTMLElement;
   title?: ReactNode;

--- a/docs/step.md
+++ b/docs/step.md
@@ -46,6 +46,10 @@ Check [react-floater](https://github.com/gilbarbara/react-floater) for more info
 **placementBeacon** {string} ▶︎ placement  
 The placement of the beacon. It will use the placement if nothing is passed and it can be: `top, bottom, left, right`.
 
+**spotlightTarget** {Element\|string} ▶︎ target
+The target for the step spotlight. It can be a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) or an HTMLElement directly \(but using refs created in the same render would required an additional render afterwards\).
+It will use the target if nothing is passed.
+
 **styles** {Object}  
 Override the [styling](styling.md) of the step's Tooltip
 

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -156,12 +156,12 @@ export default class JoyrideOverlay extends React.Component {
       target,
     } = this.props;
 
-    let targetToSpotlight = target;
+    let currentTarget = target;
     if (spotlightTarget && is.domElement(getElement(spotlightTarget))) {
-      targetToSpotlight = spotlightTarget;
+      currentTarget = spotlightTarget;
     }
 
-    const element = getElement(targetToSpotlight);
+    const element = getElement(currentTarget);
     const elementRect = getClientRect(element);
     const isFixedTarget = isFixed(element);
     const top = getElementPosition(element, spotlightPadding, disableScrollParentFix);

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import treeChanges from 'tree-changes';
+import is from 'is-lite';
 
 import {
   getClientRect,
@@ -38,6 +39,7 @@ export default class JoyrideOverlay extends React.Component {
     placement: PropTypes.string.isRequired,
     spotlightClicks: PropTypes.bool.isRequired,
     spotlightPadding: PropTypes.number,
+    spotlightTarget: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     styles: PropTypes.object.isRequired,
     target: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   };
@@ -149,10 +151,17 @@ export default class JoyrideOverlay extends React.Component {
       disableScrollParentFix,
       spotlightClicks,
       spotlightPadding,
+      spotlightTarget,
       styles,
       target,
     } = this.props;
-    const element = getElement(target);
+
+    let targetToSpotlight = target;
+    if (spotlightTarget && is.domElement(getElement(spotlightTarget))) {
+      targetToSpotlight = spotlightTarget;
+    }
+
+    const element = getElement(targetToSpotlight);
     const elementRect = getClientRect(element);
     const isFixedTarget = isFixed(element);
     const top = getElementPosition(element, spotlightPadding, disableScrollParentFix);

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -68,6 +68,7 @@ export default class JoyrideStep extends React.Component {
       ]),
       spotlightClicks: PropTypes.bool,
       spotlightPadding: PropTypes.number,
+      spotlightTarget: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
       styles: PropTypes.object,
       target: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
       title: PropTypes.node,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,6 +79,7 @@ export interface Step {
   showSkipButton?: boolean;
   spotlightClicks?: boolean;
   spotlightPadding?: number;
+  spotlightTarget: string | HTMLElement;
   styles?: object;
   target: string | HTMLElement;
   title?: React.ReactNode;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,7 +79,7 @@ export interface Step {
   showSkipButton?: boolean;
   spotlightClicks?: boolean;
   spotlightPadding?: number;
-  spotlightTarget: string | HTMLElement;
+  spotlightTarget?: string | HTMLElement;
   styles?: object;
   target: string | HTMLElement;
   title?: React.ReactNode;


### PR DESCRIPTION
Added new prop "spotlightTarget" to define target element which needs to be spotlighted, and is different than the target for the tooltip.

It can be helpful when you want to position the tooltip with the very specific element, but want to spotlight another one, for example, `target` will point to the element which is precisely positioned inside the element which is spotlighted.