### PR TITLE
Issue 478: move `if` statement inside setTimeout to prevent type errors

### DIFF
--- a/src/components/Beacon.js
+++ b/src/components/Beacon.js
@@ -60,11 +60,11 @@ export default class JoyrideBeacon extends React.Component {
       }
     }
 
-    if (is.domElement(this.beacon)) {
-      setTimeout(() => {
+    setTimeout(() => {
+      if (is.domElement(this.beacon)) {
         this.beacon.focus();
-      }, 0);
-    }
+      }
+    }, 0);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
A solution for a bug described in this issue: https://github.com/gilbarbara/react-joyride/issues/478