### PR TITLE
More strict type for "styles" property in typescript definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,7 +79,7 @@ export interface Step {
   showSkipButton?: boolean;
   spotlightClicks?: boolean;
   spotlightPadding?: number;
-  styles?: object;
+  styles?: React.CSSProperties;
   target: string | HTMLElement;
   title?: React.ReactNode;
   tooltipComponent?: (renderProps: TooltipRenderProps) => React.ReactNode;
@@ -153,7 +153,7 @@ export interface Props {
   spotlightPadding?: number;
   stepIndex?: number;
   steps: Array<Step>;
-  styles?: object;
+  styles?: React.CSSProperties;
   tooltipComponent?: (renderProps: TooltipRenderProps) => React.ReactNode;
 }
 


### PR DESCRIPTION
I've tried apply these rules to propTypes also, but as far as I know, it will require package like https://www.npmjs.com/package/react-style-proptype.

Closes #480.