### PR TITLE
add disableAnimation to FloaterOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,6 +60,7 @@ export interface FloaterProps {
   options?: object;
   styles?: object;
   wrapperOptions?: object;
+  disableAnimation?: boolean;
 }
 
 export interface Styles {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,10 +57,10 @@ export interface CallBackProps {
 }
 
 export interface FloaterProps {
+  disableAnimation?: boolean;
   options?: object;
   styles?: object;
   wrapperOptions?: object;
-  disableAnimation?: boolean;
 }
 
 export interface Styles {


### PR DESCRIPTION
add disableAnimation to FloaterOptions to disable the default fly-in animation.

currently only options, styles, and wrapperOptions are passed into Floater. Floater now takes disableAnimation as a prop.