### PR TITLE
Replaced README image with typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://badge.fury.io/js/react-joyride.svg)](https://www.npmjs.com/package/react-joyride) [![](https://travis-ci.org/gilbarbara/react-joyride.svg)](https://travis-ci.org/gilbarbara/react-joyride) [![](https://api.codeclimate.com/v1/badges/43ecb5536910133429bd/maintainability)](https://codeclimate.com/github/gilbarbara/react-joyride/maintainability) [![](https://api.codeclimate.com/v1/badges/43ecb5536910133429bd/test_coverage)](https://codeclimate.com/github/gilbarbara/react-joyride/test_coverage)
 
-[![Joyride example image](http://gilbarbara.com/files/react-joyride.png)](https://react-joyride.com/)
+[![Joyride example image](https://live.staticflickr.com/7808/32632471737_1a6122e484_b.jpg)](https://react-joyride.com/)
 
 #### Create awesome tours for your app!
 


### PR DESCRIPTION
Replaced image on the React Joyride README that included a typo as pointed out in #506 . 

![Screen Shot 2019-04-09 at 3 40 09 PM](https://user-images.githubusercontent.com/28833112/55891313-2e6b7a00-5b69-11e9-9e32-07874176df7a.png)
