### PR TITLE
Introducing a nodeId prop for using portal and rendering to an existing dom node

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,4 @@
-
-version: "2"
+version: '2'
 checks:
   argument-count:
     config:
@@ -21,7 +20,7 @@ checks:
       threshold: 20
   method-lines:
     config:
-      threshold: 50
+      threshold: 100
   similar-code:
     config:
       threshold: 100

--- a/src/components/Portal.js
+++ b/src/components/Portal.js
@@ -9,19 +9,27 @@ export default class JoyridePortal extends React.Component {
 
     if (!canUseDOM) return;
 
-    this.node = document.createElement('div');
+    /**
+     * Portal to an existing DOM node.
+     */
+    const { nodeId } = this.props;
+    this.node = nodeId ? document.getElementById(nodeId) : document.createElement('div');
 
     /* istanbul ignore else */
-    if (props.id) {
+    if (props.id && !nodeId) {
       this.node.id = props.id;
     }
 
-    document.body.appendChild(this.node);
+    /**
+     * Append DOM node only if it's a newly created one.
+     */
+    if (!nodeId) document.body.appendChild(this.node);
   }
 
   static propTypes = {
     children: PropTypes.element,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    nodeId: PropTypes.string,
   };
 
   componentDidMount() {
@@ -47,7 +55,11 @@ export default class JoyridePortal extends React.Component {
       ReactDOM.unmountComponentAtNode(this.node);
     }
 
-    document.body.removeChild(this.node);
+    const { nodeId } = this.props;
+    /**
+     * If it's an existing DOM node, don't remove it.
+     */
+    if (!nodeId) document.body.removeChild(this.node);
   }
 
   renderReact15() {

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -29,6 +29,10 @@ export default class JoyrideStep extends React.Component {
     helpers: PropTypes.object.isRequired,
     index: PropTypes.number.isRequired,
     lifecycle: PropTypes.string.isRequired,
+    /**
+     * Portal to an existing DOM node.
+     */
+    nodeId: PropTypes.string,
     setPopper: PropTypes.func.isRequired,
     shouldScroll: PropTypes.bool.isRequired,
     size: PropTypes.number.isRequired,
@@ -258,7 +262,17 @@ export default class JoyrideStep extends React.Component {
   }
 
   render() {
-    const { continuous, debug, helpers, index, lifecycle, shouldScroll, size, step } = this.props;
+    const {
+      continuous,
+      debug,
+      helpers,
+      index,
+      lifecycle,
+      shouldScroll,
+      size,
+      step,
+      nodeId,
+    } = this.props;
     const target = getElement(step.target);
 
     if (!validateStep(step) || !is.domElement(target)) {
@@ -267,7 +281,7 @@ export default class JoyrideStep extends React.Component {
 
     return (
       <div key={`JoyrideStep-${index}`} className="react-joyride__step">
-        <Portal id="react-joyride-portal">
+        <Portal id="react-joyride-portal" nodeId={nodeId}>
           <Overlay
             {...step}
             debug={debug}

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -268,10 +268,10 @@ export default class JoyrideStep extends React.Component {
       helpers,
       index,
       lifecycle,
+      nodeId,
       shouldScroll,
       size,
       step,
-      nodeId,
     } = this.props;
     const target = getElement(step.target);
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -45,6 +45,7 @@ class Joyride extends React.Component {
     getHelpers: PropTypes.func,
     hideBackButton: PropTypes.bool,
     locale: PropTypes.object,
+    nodeId: PropTypes.string,
     run: PropTypes.bool,
     scrollOffset: PropTypes.number,
     scrollToFirstStep: PropTypes.bool,
@@ -371,7 +372,7 @@ class Joyride extends React.Component {
     if (!canUseDOM) return null;
 
     const { index, status } = this.state;
-    const { continuous, debug, disableScrolling, scrollToFirstStep, steps } = this.props;
+    const { continuous, debug, disableScrolling, nodeId, scrollToFirstStep, steps } = this.props;
     const step = getMergedStep(steps[index], this.props);
     let output;
 
@@ -384,6 +385,7 @@ class Joyride extends React.Component {
           debug={debug}
           setPopper={this.setPopper}
           helpers={this.helpers}
+          nodeId={nodeId}
           shouldScroll={!disableScrolling && (index !== 0 || scrollToFirstStep)}
           step={step}
           update={this.store.update}


### PR DESCRIPTION
Sometimes you don't wanna bubble the react-joyride-portal to document.body, 
this way we can render it to a specific node.

@gilbarbara thoughts?