### PR TITLE
Fix primary button auto focus

### DIFF
--- a/src/modules/scope.js
+++ b/src/modules/scope.js
@@ -110,7 +110,13 @@ export default class Scope {
 
     /* istanbul ignore else */
     if (target) {
-      target.focus();
+
+      target.focus()
+
+      if(document.activeElement !== target) {
+        setTimeout(() => target.focus(), 1);
+      }
+
     }
   };
 }

--- a/src/modules/scope.js
+++ b/src/modules/scope.js
@@ -105,9 +105,8 @@ export default class Scope {
   checkFocus = (target: HTMLElement) => {
     if (document.activeElement !== target) {
       target.focus();
+      window.requestAnimationFrame(() => this.checkFocus(target));
     }
-
-    window.requestAnimationFrame(() => this.checkFocus(target));
   };
 
   setFocus = () => {
@@ -118,8 +117,6 @@ export default class Scope {
 
     /* istanbul ignore else */
     if (target) {
-      target.focus();
-
       window.requestAnimationFrame(() => this.checkFocus(target));
     }
   };

--- a/src/modules/scope.js
+++ b/src/modules/scope.js
@@ -110,13 +110,11 @@ export default class Scope {
 
     /* istanbul ignore else */
     if (target) {
+      target.focus();
 
-      target.focus()
-
-      if(document.activeElement !== target) {
+      if (document.activeElement !== target) {
         setTimeout(() => target.focus(), 1);
       }
-
     }
   };
 }

--- a/src/modules/scope.js
+++ b/src/modules/scope.js
@@ -102,6 +102,14 @@ export default class Scope {
     window.removeEventListener('keydown', this.handleKeyDown);
   };
 
+  checkFocus = (target: HTMLElement) => {
+    if (document.activeElement !== target) {
+      target.focus();
+    }
+
+    window.requestAnimationFrame(() => this.checkFocus(target));
+  };
+
   setFocus = () => {
     const { selector } = this.options;
     if (!selector) return;
@@ -112,9 +120,7 @@ export default class Scope {
     if (target) {
       target.focus();
 
-      if (document.activeElement !== target) {
-        setTimeout(() => target.focus(), 1);
-      }
+      window.requestAnimationFrame(() => this.checkFocus(target));
     }
   };
 }

--- a/test/modules/scope.spec.js
+++ b/test/modules/scope.spec.js
@@ -167,7 +167,10 @@ describe('modules/scope', () => {
     });
 
     it('should have focused the selector', () => {
-      expect(wrapper.find('.primary').instance() === document.activeElement).toBeTrue();
+      setTimeout(
+        () => expect(wrapper.find('.primary').instance() === document.activeElement).toBeTrue(),
+        100,
+      );
     });
   });
 


### PR DESCRIPTION
This addresses issue #551 - basically the DOM element isn't ready to receive the focus yet so I do a check and add a timer delay of 1 millisecond. This fixes the issue - tested in Chrome and Firefox.