### PR TITLE
Add width and height to spotlight steps styles

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -165,6 +165,8 @@ export default function getStyles(stepStyles = {}) {
     spotlight: {
       ...spotlight,
       backgroundColor: 'gray',
+      width: '100%',
+      height: '100%',
     },
     spotlightLegacy: {
       ...spotlight,


### PR DESCRIPTION
To improve the ability of creating circles with spotlight without the need to make a component just for this sole purpose.