### PR TITLE
Replace scroll-doc with the native scrollingElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ export class App extends React.Component {
 }
 ```
 
+> If you need to support legacy browsers you need to include the [scrollingelement](https://github.com/mathiasbynens/document.scrollingElement) polyfill.
+
 ## Development
 
 Setting up a local development environment is easy!

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,3 +54,4 @@ export class App extends React.Component {
 }
 ```
 
+> If you need to support legacy browsers you need to include the [scrollingelement](https://github.com/mathiasbynens/document.scrollingElement) polyfill.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8546,11 +8546,6 @@
       "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
       "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg=="
     },
-    "scrollingelement": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/scrollingelement/-/scrollingelement-1.5.2.tgz",
-      "integrity": "sha1-tjtxEU2GTjZxyh6FTqH5OvYfEH4="
-    },
     "scrollparent": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8546,10 +8546,10 @@
       "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
       "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg=="
     },
-    "scroll-doc": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/scroll-doc/-/scroll-doc-0.2.1.tgz",
-      "integrity": "sha512-ZLueZaKMkdL1/SL07Fpw/P/MFYit76GaaKQYnjLSx2K6dOUmkYP1TEOyyfKZohvDyoKMwue0l9MbgPesREjqCA=="
+    "scrollingelement": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/scrollingelement/-/scrollingelement-1.5.2.tgz",
+      "integrity": "sha1-tjtxEU2GTjZxyh6FTqH5OvYfEH4="
     },
     "scrollparent": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react-floater": "^0.6.5",
     "react-is": "^16.8.6",
     "scroll": "^3.0.1",
-    "scrollingelement": "^1.5.2",
     "scrollparent": "^2.0.1",
     "tree-changes": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-floater": "^0.6.5",
     "react-is": "^16.8.6",
     "scroll": "^3.0.1",
-    "scroll-doc": "^0.2.1",
+    "scrollingelement": "^1.5.2",
     "scrollparent": "^2.0.1",
     "tree-changes": "^0.4.0"
   },

--- a/src/modules/dom.js
+++ b/src/modules/dom.js
@@ -1,12 +1,10 @@
 // @flow
 import scroll from 'scroll';
-import 'scrollingelement';
 import scrollParent from 'scrollparent';
 
-const scrollDoc = (): HTMLElement => {
-  const { scrollingElement } = document;
-  return scrollingElement || document.createElement('body');
-};
+export function scrollDoc(): HTMLElement {
+  return document.scrollingElement || document.createElement('body');
+}
 
 /**
  * Find the bounding client rect

--- a/src/modules/dom.js
+++ b/src/modules/dom.js
@@ -1,7 +1,12 @@
 // @flow
 import scroll from 'scroll';
-import scrollDoc from 'scroll-doc';
+import 'scrollingelement';
 import scrollParent from 'scrollparent';
+
+const scrollDoc = (): HTMLElement => {
+  const { scrollingElement } = document;
+  return scrollingElement || document.createElement('body');
+};
 
 /**
  * Find the bounding client rect

--- a/test/__setup__/setupFiles.js
+++ b/test/__setup__/setupFiles.js
@@ -31,3 +31,7 @@ window.matchMedia = () => ({
   addListener: () => {},
   removeListener: () => {},
 });
+
+document.scrollingElement = {
+  isSameNode: () => true,
+};


### PR DESCRIPTION
**Fix**
Replace scroll-doc for the new standard scrollingElement and add a polyfill for IE. Fixes the highlight area not showing properly on IE 11. This closes #517

**Reason**
`scroll-doc` doesn't work on IE before the body is loaded. It tries to change `document.documentElement.scrollTop` but until the body loads it doesn't work on IE and since it caches that value it does not work in subsequent calls. 

`document.scrollingElement` is the new way of scrolling (what `scroll-doc` returns for chrome) and seems like it's the way of doing it moving forward. Using a polyfill allows it to work properly on IE as well