### PR TITLE
fix getPopper chaining

### DIFF
--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -43,6 +43,7 @@ export default class JoyrideStep extends React.Component {
       disableScrollParentFix: PropTypes.bool,
       event: PropTypes.string,
       floaterProps: PropTypes.shape({
+        getPopper: PropTypes.func,
         options: PropTypes.object,
         styles: PropTypes.object,
         wrapperOptions: PropTypes.object,
@@ -234,7 +235,7 @@ export default class JoyrideStep extends React.Component {
   };
 
   setPopper = (popper, type) => {
-    const { action, setPopper, update } = this.props;
+    const { action, setPopper, update, step } = this.props;
 
     if (type === 'wrapper') {
       this.beaconPopper = popper;
@@ -249,6 +250,10 @@ export default class JoyrideStep extends React.Component {
         action: action === ACTIONS.CLOSE ? ACTIONS.CLOSE : action,
         lifecycle: LIFECYCLE.READY,
       });
+    }
+
+    if (step && step.floaterProps && step.floaterProps.getPopper) {
+      step.floaterProps.getPopper(popper, type);
     }
   };
 
@@ -289,13 +294,13 @@ export default class JoyrideStep extends React.Component {
             />
           }
           debug={debug}
-          getPopper={this.setPopper}
           id={`react-joyride-step-${index}`}
           isPositioned={step.isFixed || hasPosition(target)}
           open={this.open}
           placement={step.placement}
           target={step.target}
           {...step.floaterProps}
+          getPopper={this.setPopper}
         >
           <Beacon
             beaconComponent={step.beaconComponent}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Props as ReactFloaterProps } from 'react-floater';
 
 export type valueof<T> = T[keyof T];
 
@@ -64,12 +65,10 @@ export interface GenericObject {
   [key: string]: any;
 }
 
-export interface FloaterProps {
-  disableAnimation?: boolean;
-  options?: GenericObject;
-  styles?: GenericObject;
-  wrapperOptions?: GenericObject;
-}
+export type FloaterProps = Pick<
+  ReactFloaterProps,
+  'disableAnimation' | 'options' | 'styles' | 'wrapperOptions' | 'getPopper'
+>;
 
 export interface Styles {
   beacon?: React.CSSProperties;


### PR DESCRIPTION
Added proper support for `getPopper` floater prop to access the underlying popper.js instance. Should fix #600 as well.