### PR TITLE
Import FloaterProps directly from react-floater

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,10 +61,6 @@ export interface CallBackProps {
   type: string;
 }
 
-export interface GenericObject {
-  [key: string]: any;
-} 
-  
 export interface Styles {
   beacon?: React.CSSProperties;
   beaconInner?: React.CSSProperties;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -237,3 +237,4 @@ export const ACTIONS: actions;
 export const EVENTS: events;
 export const LIFECYCLE: lifecycle;
 export const STATUS: status;
+export type FloaterProps = FloaterProps;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Props as FloaterProps } from "react-floater";
 
 export type valueof<T> = T[keyof T];
 
@@ -62,15 +63,8 @@ export interface CallBackProps {
 
 export interface GenericObject {
   [key: string]: any;
-}
-
-export interface FloaterProps {
-  disableAnimation?: boolean;
-  options?: GenericObject;
-  styles?: GenericObject;
-  wrapperOptions?: GenericObject;
-}
-
+} 
+  
 export interface Styles {
   beacon?: React.CSSProperties;
   beaconInner?: React.CSSProperties;


### PR DESCRIPTION
Any reasons we don't just take all the props from react-floater? The JSDoc comments are helpful too. If we don't want to expose all the properties we could do something like `Omit` them.