### PR TITLE
Fix misplaced overlay

### DIFF
--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -101,17 +101,11 @@ export default class JoyrideOverlay extends React.Component {
 
   get spotlightStyles() {
     const { showSpotlight } = this.state;
-    const {
-      disableScrollParentFix,
-      spotlightClicks,
-      spotlightPadding,
-      styles,
-      target,
-    } = this.props;
+    const { spotlightClicks, spotlightPadding, styles, target } = this.props;
     const element = getElement(target);
     const elementRect = getClientRect(element);
     const isFixedTarget = hasPosition(element);
-    const top = getElementPosition(element, spotlightPadding, disableScrollParentFix);
+    const top = getElementPosition(element, spotlightPadding);
 
     return {
       ...(isLegacy() ? styles.spotlightLegacy : styles.spotlight),

--- a/src/modules/dom.js
+++ b/src/modules/dom.js
@@ -226,24 +226,12 @@ export function isElementVisible(element: ?HTMLElement): boolean {
  * @private
  * @param {string|HTMLElement} element
  * @param {number} offset
- * @param {boolean} skipFix
  *
  * @returns {HTMLElement|undefined}
  */
-export function getElementPosition(element: HTMLElement, offset: number, skipFix: boolean): number {
-  const elementRect = getClientRect(element);
-  const parent = getScrollParent(element, skipFix);
-  const hasScrollParent = hasCustomScrollParent(element, skipFix);
-  let parentTop = 0;
-
-  /* istanbul ignore else */
-  if (parent instanceof HTMLElement) {
-    parentTop = parent.scrollTop;
-  }
-
-  const top = elementRect.top + (!hasScrollParent && !hasPosition(element) ? parentTop : 0);
-
-  return Math.floor(top - offset);
+export function getElementPosition(element: HTMLElement, offset: number): number {
+  const { top } = getClientRect(element);
+  return Math.floor(top + window.scrollY - offset);
 }
 
 /**


### PR DESCRIPTION
Fixes #594

Absolute-positioned elements would break the positioning from the old
overlay position calculation. This calculation is simpler and works for
all cases.