### PR TITLE
Fix step disableScrolling

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -272,7 +272,6 @@ class Joyride extends React.Component {
     const { index, lifecycle, status } = this.state;
     const {
       debug,
-      disableScrolling,
       disableScrollParentFix,
       scrollToFirstStep,
       scrollOffset,
@@ -285,7 +284,7 @@ class Joyride extends React.Component {
     if (step) {
       const target = getElement(step.target);
       const shouldScroll = this.shouldScroll(
-        disableScrolling,
+        step.disableScrolling,
         index,
         scrollToFirstStep,
         lifecycle,


### PR DESCRIPTION
This hotfix fixes disabling step auto scroll function after defining `disableScrolling` property inside step object.

refs: #732 