### PR TITLE
Only focus if scrolling is not disabled

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-./node_modules/.bin/repo-tools check-remote && lint-staged && flow
+./node_modules/.bin/repo-tools check-remote && ./node_modules/.bin/lint-staged && ./node_modules/.bin/flow

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -103,6 +103,7 @@ export default class JoyrideStep extends React.Component {
       status,
       step,
       update,
+      shouldScroll,
     } = this.props;
     const { changed, changedFrom } = treeChanges(prevProps, this.props);
     const state = { action, controlled, index, lifecycle, size, status };
@@ -202,8 +203,10 @@ export default class JoyrideStep extends React.Component {
         type: EVENTS.TOOLTIP,
       });
 
-      this.scope = new Scope(this.tooltip, { selector: '[data-action=primary]' });
-      this.scope.setFocus();
+      this.scope = new Scope(this.tooltip, {
+        selector: '[data-action=primary]',
+        initialSetFocus: shouldScroll,
+      });
     }
 
     if (changedFrom('lifecycle', [LIFECYCLE.TOOLTIP, LIFECYCLE.INIT], LIFECYCLE.INIT)) {

--- a/src/modules/scope.js
+++ b/src/modules/scope.js
@@ -14,7 +14,9 @@ export default class Scope {
 
     window.addEventListener('keydown', this.handleKeyDown, false);
 
-    this.setFocus();
+    if (this.options.initialSetFocus !== false) {
+      this.setFocus();
+    }
   }
 
   canBeTabbed = (element: HTMLElement): boolean => {


### PR DESCRIPTION
Fixes https://github.com/gilbarbara/react-joyride/issues/817

This changes so that the Scope does not auto-focus unless `scrollToFirstStep` is set to true and `disableScrolling` is not false. This may or may not be desirable behavior, but it wasn't clear to me what _would_ be the right thing to do.

Additionally, changes husky pre-commit to find commands from the local node_modules bin folder, for some reason on my Mac it was not able to find `lint-staged`. Not sure if that's just a me issue or a general issue.