### PR TITLE
Fix support of floaterProps.getPopper

### DIFF
--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -44,6 +44,7 @@ export default class JoyrideStep extends React.Component {
       disableScrollParentFix: PropTypes.bool,
       event: PropTypes.string,
       floaterProps: PropTypes.shape({
+        getPopper: PropTypes.func,
         options: PropTypes.object,
         styles: PropTypes.object,
         wrapperOptions: PropTypes.object,
@@ -245,7 +246,7 @@ export default class JoyrideStep extends React.Component {
   };
 
   setPopper = (popper, type) => {
-    const { action, setPopper, update } = this.props;
+    const { action, setPopper, update, step } = this.props;
 
     if (type === 'wrapper') {
       this.beaconPopper = popper;
@@ -254,6 +255,10 @@ export default class JoyrideStep extends React.Component {
     }
 
     setPopper(popper, type);
+
+    if (step.floaterProps && typeof step.floaterProps.getPopper === 'function') {
+      step.floaterProps.getPopper(popper, type);
+    }
 
     if (this.beaconPopper && this.tooltipPopper) {
       update({
@@ -289,6 +294,7 @@ export default class JoyrideStep extends React.Component {
           />
         </Portal>
         <Floater
+          {...step.floaterProps}
           component={
             <Tooltip
               continuous={continuous}
@@ -307,7 +313,6 @@ export default class JoyrideStep extends React.Component {
           open={this.open}
           placement={step.placement}
           target={step.target}
-          {...step.floaterProps}
         >
           <Beacon
             beaconComponent={step.beaconComponent}

--- a/test/__fixtures__/WithFloaterGetPopper.js
+++ b/test/__fixtures__/WithFloaterGetPopper.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Joyride, { STATUS } from '../../src/index';
+
+import tourSteps from './steps';
+
+const filteredSteps = tourSteps
+  .filter((d, i) => i !== 3)
+  .map(d => {
+    if (d.target === '.mission button') {
+      d.target = '.mission h2';
+    }
+
+    return d;
+  });
+
+export default class WithFloaterGetPopper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const steps = [...filteredSteps];
+
+    if (props.withCentered) {
+      steps.push({
+        target: 'body',
+        placement: 'center',
+        content: "Let's begin our journey",
+        textAlign: 'center',
+      });
+    }
+
+    this.state = {
+      run: false,
+      steps,
+    };
+  }
+
+  static propTypes = {
+    callback: PropTypes.func.isRequired,
+  };
+
+  handleClickStart = () => {
+    this.setState({
+      run: true,
+    });
+  };
+
+  handleJoyrideCallback = data => {
+    const { callback } = this.props;
+    const { status } = data;
+
+    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+      this.setState({ run: false });
+    }
+
+    callback(data);
+  };
+
+  render() {
+    const { run, steps } = this.state;
+    const { floaterProps } = this.props;
+
+    return (
+      <div className="demo">
+        <Joyride
+          run={run}
+          steps={steps}
+          continuous
+          scrollToFirstStep
+          showSkipButton={true}
+          callback={this.handleJoyrideCallback}
+          floaterProps={floaterProps}
+        />
+        <main>
+          <div className="hero">
+            <div className="container">
+              <div className="hero__content">
+                <h1>
+                  <span>Create walkthroughs and guided tours for your ReactJS apps.</span>
+                </h1>
+                <button className="hero__start" onClick={this.handleClickStart} type="button">
+                  Let's Go!
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="demo__section projects">
+            <div className="container">
+              <h2>
+                <span>Projects</span>
+              </h2>
+              <div className="list">
+                <div>
+                  <img
+                    src="http://placehold.it/800x600/ff0044/ffffff?txtsize=50&text=ASBESTOS"
+                    alt="ASBESTOS"
+                  />
+                </div>
+                <div>
+                  <img
+                    src="http://placehold.it/800x600/00ff44/ffffff?txtsize=50&text=GROW"
+                    alt="GROW"
+                  />
+                </div>
+                <div>
+                  <img
+                    src="http://placehold.it/800x600/333/ffffff?txtsize=50&text=∂Vo∑"
+                    alt="∂Vo∑"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="demo__section mission">
+            <div className="container">
+              <h2>
+                <span>Mission</span>
+              </h2>
+            </div>
+          </div>
+          <div className="demo__section about">
+            <div className="container">
+              <h2>
+                <span>About</span>
+              </h2>
+            </div>
+          </div>
+        </main>
+        <footer className="demo__footer">
+          <div className="container">
+            <button type="button">
+              <span />
+            </button>
+            JOYRIDE
+          </div>
+        </footer>
+      </div>
+    );
+  }
+}

--- a/test/tours/__snapshots__/with-floater-get-popper.spec.js.snap
+++ b/test/tours/__snapshots__/with-floater-get-popper.spec.js.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 1 Beacon 1`] = `
+{
+  "action": "update",
+  "controlled": false,
+  "index": 0,
+  "lifecycle": "tooltip",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 1 Primary button 1`] = `
+{
+  "action": "next",
+  "controlled": false,
+  "index": 1,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 2 Primary button 1`] = `
+{
+  "action": "next",
+  "controlled": false,
+  "index": 2,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 2 Primary button AGAIN 1`] = `
+{
+  "action": "next",
+  "controlled": false,
+  "index": 2,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 3 Back button 1`] = `
+{
+  "action": "prev",
+  "controlled": false,
+  "index": 1,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 3 Primary button 1`] = `
+{
+  "action": "next",
+  "controlled": false,
+  "index": 3,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 4 Primary button 1`] = `
+{
+  "action": "update",
+  "controlled": false,
+  "index": 4,
+  "lifecycle": "tooltip",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to click STEP 5 Primary button 1`] = `
+{
+  "action": "stop",
+  "controlled": false,
+  "index": 0,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "paused",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should be able to start the tour 1`] = `
+{
+  "action": "start",
+  "controlled": false,
+  "index": 0,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should have ended the tour 1`] = `
+{
+  "action": "stop",
+  "controlled": false,
+  "index": 0,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "paused",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should have initiated the Joyride 1`] = `
+{
+  "action": "init",
+  "controlled": false,
+  "index": 0,
+  "lifecycle": "init",
+  "size": 5,
+  "status": "ready",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should have rendered the STEP 3 Tooltip 1`] = `
+{
+  "action": "update",
+  "controlled": false,
+  "index": 2,
+  "lifecycle": "tooltip",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should have rendered the STEP 3 Tooltip AGAIN 1`] = `
+{
+  "action": "update",
+  "controlled": false,
+  "index": 2,
+  "lifecycle": "tooltip",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should have rendered the STEP 4 Tooltip 1`] = `
+{
+  "action": "update",
+  "controlled": false,
+  "index": 3,
+  "lifecycle": "tooltip",
+  "size": 5,
+  "status": "running",
+}
+`;
+
+exports[`Joyride > With floaterProps.getPopper should have rendered the STEP 5 Tooltip 1`] = `
+{
+  "action": "update",
+  "controlled": false,
+  "index": 4,
+  "lifecycle": "ready",
+  "size": 5,
+  "status": "running",
+}
+`;

--- a/test/tours/with-floater-get-popper.spec.js
+++ b/test/tours/with-floater-get-popper.spec.js
@@ -1,0 +1,474 @@
+import React from 'react';
+
+import WithFloaterGetPopper from '../__fixtures__/WithFloaterGetPopper';
+
+import { ACTIONS, EVENTS, LIFECYCLE, STATUS } from '../../src';
+
+jest.mock('popper.js', () => {
+  const PopperJS = jest.requireActual('popper.js');
+
+  return class {
+    static placements = PopperJS.placements;
+
+    constructor() {
+      return {
+        destroy: () => {},
+        scheduleUpdate: () => {},
+      };
+    }
+  };
+});
+
+console.warn = jest.fn();
+
+const mockCallback = jest.fn();
+const floaterGetPopper = jest.fn();
+const props = {
+  callback: mockCallback,
+  withCentered: true,
+  floaterProps: {
+    getPopper: floaterGetPopper,
+  },
+};
+
+let stepSetPopperSpy;
+
+function initPopper(wrapper) {
+  const Step = wrapper.find('JoyrideStep').instance();
+  stepSetPopperSpy = jest.spyOn(Step, 'setPopper');
+  /* required to update Floater.props.getPropper with mocked reference, cause setPopper is not a class fn */
+  wrapper.update();
+  wrapper.instance().forceUpdate();
+
+  /* contrary to other tests, call props.getPopper in Floater to validate full chain */
+  const Floater = wrapper.find('ReactFloater').instance();
+  Floater.props.getPopper({ popper: {} }, 'wrapper');
+  Floater.props.getPopper({ popper: {} }, 'tooltip');
+}
+
+function getCallbackResponse(input) {
+  return {
+    controlled: false,
+    size: 5,
+    status: STATUS.RUNNING,
+    step: expect.any(Object),
+    ...input,
+  };
+}
+
+describe('Joyride > With floaterProps.getPopper', () => {
+  let wrapper;
+  let joyride;
+  let joyrideSetPopperSpy;
+
+  beforeAll(() => {
+    wrapper = mount(<WithFloaterGetPopper {...props} />, {
+      attachTo: document.getElementById('react'),
+    });
+    joyride = wrapper.find('Joyride').instance();
+    joyrideSetPopperSpy = jest.spyOn(joyride, 'setPopper');
+  });
+
+  it('should have initiated the Joyride', () => {
+    expect(joyride.state).toMatchSnapshot();
+  });
+
+  it('should not have rendered a step', () => {
+    window.dispatchEvent(new Event('resize'));
+    expect(wrapper.find('Joyride')).toExist();
+    expect(wrapper.find('JoyrideStep')).not.toExist();
+    expect(joyrideSetPopperSpy).toBeCalledTimes(0);
+    expect(stepSetPopperSpy).toBeUndefined();
+  });
+
+  it('should be able to start the tour', () => {
+    wrapper.find('.hero__start').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      1,
+      getCallbackResponse({
+        action: ACTIONS.START,
+        index: 0,
+        lifecycle: LIFECYCLE.INIT,
+        type: EVENTS.TOUR_START,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 1 Beacon', () => {
+    initPopper(wrapper);
+
+    expect(stepSetPopperSpy).not.toBeUndefined();
+    expect(floaterGetPopper).toBeCalledTimes(2);
+    expect(stepSetPopperSpy).toBeCalledTimes(2);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(2);
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      2,
+      getCallbackResponse({
+        action: ACTIONS.START,
+        index: 0,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      3,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 0,
+        lifecycle: LIFECYCLE.BEACON,
+        type: EVENTS.BEACON,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 1 Beacon', () => {
+    wrapper.find('JoyrideBeacon').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      4,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 0,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 1 Primary button', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-primary"]').simulate('click');
+
+    window.dispatchEvent(new Event('keydown', { keyCode: 9 }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 }));
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      5,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 0,
+        lifecycle: LIFECYCLE.COMPLETE,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 2 Tooltip', () => {
+    initPopper(wrapper);
+
+    expect(floaterGetPopper).toBeCalledTimes(4);
+    expect(stepSetPopperSpy).toBeCalledTimes(4);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(4);
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      6,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 1,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      7,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 1,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 2 Primary button', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-primary"]').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      8,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 1,
+        lifecycle: LIFECYCLE.COMPLETE,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 3 Tooltip', () => {
+    initPopper(wrapper);
+
+    expect(floaterGetPopper).toBeCalledTimes(6);
+    expect(stepSetPopperSpy).toBeCalledTimes(6);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(6);
+
+    expect(joyride.state).toMatchSnapshot();
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      9,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 2,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      10,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 2,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 3 Back button', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-back"]').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      11,
+      getCallbackResponse({
+        action: ACTIONS.PREV,
+        index: 2,
+        lifecycle: LIFECYCLE.COMPLETE,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 2 Tooltip and advance AGAIN', () => {
+    initPopper(wrapper);
+
+    expect(floaterGetPopper).toBeCalledTimes(8);
+    expect(stepSetPopperSpy).toBeCalledTimes(8);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(8);
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      12,
+      getCallbackResponse({
+        action: ACTIONS.PREV,
+        index: 1,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      13,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 1,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 2 Primary button AGAIN', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-primary"]').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      14,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 1,
+        lifecycle: LIFECYCLE.COMPLETE,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 3 Tooltip AGAIN', () => {
+    initPopper(wrapper);
+
+    expect(floaterGetPopper).toBeCalledTimes(10);
+    expect(stepSetPopperSpy).toBeCalledTimes(10);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(10);
+
+    expect(joyride.state).toMatchSnapshot();
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      15,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 2,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      16,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 2,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 3 Primary button', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-primary"]').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      17,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 2,
+        lifecycle: LIFECYCLE.COMPLETE,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 4 Tooltip', () => {
+    initPopper(wrapper);
+
+    expect(floaterGetPopper).toBeCalledTimes(12);
+    expect(stepSetPopperSpy).toBeCalledTimes(12);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(12);
+
+    expect(joyride.state).toMatchSnapshot();
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      18,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 3,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      19,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 3,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 4 Primary button', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-primary"]').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      20,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 3,
+        lifecycle: LIFECYCLE.COMPLETE,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have rendered the STEP 5 Tooltip', () => {
+    initPopper(wrapper);
+
+    expect(floaterGetPopper).toBeCalledTimes(14);
+    expect(stepSetPopperSpy).toBeCalledTimes(14);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(14);
+
+    expect(joyride.state).toMatchSnapshot();
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      21,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 4,
+        lifecycle: LIFECYCLE.READY,
+        type: EVENTS.STEP_BEFORE,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      22,
+      getCallbackResponse({
+        action: ACTIONS.UPDATE,
+        index: 4,
+        lifecycle: LIFECYCLE.TOOLTIP,
+        type: EVENTS.TOOLTIP,
+      }),
+    );
+  });
+
+  it('should be able to click STEP 5 Primary button', () => {
+    wrapper.find('JoyrideTooltip [data-test-id="button-primary"]').simulate('click');
+
+    expect(joyride.state).toMatchSnapshot();
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      23,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 4,
+        lifecycle: LIFECYCLE.COMPLETE,
+        status: STATUS.FINISHED,
+        type: EVENTS.STEP_AFTER,
+      }),
+    );
+  });
+
+  it('should have ended the tour', () => {
+    expect(joyride.state).toMatchSnapshot();
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      24,
+      getCallbackResponse({
+        action: ACTIONS.NEXT,
+        index: 4,
+        lifecycle: LIFECYCLE.INIT,
+        status: STATUS.FINISHED,
+        type: EVENTS.TOUR_END,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      25,
+      getCallbackResponse({
+        action: ACTIONS.RESET,
+        index: 0,
+        lifecycle: LIFECYCLE.INIT,
+        status: STATUS.READY,
+        type: EVENTS.TOUR_STATUS,
+      }),
+    );
+
+    expect(mockCallback).toHaveBeenNthCalledWith(
+      26,
+      getCallbackResponse({
+        action: ACTIONS.STOP,
+        index: 0,
+        lifecycle: LIFECYCLE.INIT,
+        status: STATUS.PAUSED,
+        type: EVENTS.TOUR_STATUS,
+      }),
+    );
+
+    expect(floaterGetPopper).toBeCalledTimes(14);
+    expect(stepSetPopperSpy).toBeCalledTimes(14);
+    expect(joyrideSetPopperSpy).toBeCalledTimes(14);
+  });
+
+  it('should unmount', () => {
+    wrapper.unmount();
+
+    expect(wrapper.find('Joyride')).not.toExist();
+  });
+});


### PR DESCRIPTION
Fixes #875 

Changed order of props passed to Floater to avoid overriding mandatory internal stuff by provided floaterProps, chained internal function to call of provided floaterProps.getPopper.

Extending PropTypes was required due to lint settings.