### PR TITLE
Allow spotlight styles to be updated from outside

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -109,7 +109,6 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
     const top = getElementPosition(element, spotlightPadding, disableScrollParentFix);
 
     return {
-      ...(isLegacy() ? styles.spotlightLegacy : styles.spotlight),
       height: Math.round((elementRect?.height ?? 0) + spotlightPadding * 2),
       left: Math.round((elementRect?.left ?? 0) - spotlightPadding),
       opacity: showSpotlight ? 1 : 0,
@@ -118,6 +117,7 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
       top,
       transition: 'opacity 0.2s',
       width: Math.round((elementRect?.width ?? 0) + spotlightPadding * 2),
+      ...(isLegacy() ? styles.spotlightLegacy : styles.spotlight),
     } satisfies React.CSSProperties;
   }
 

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -106,18 +106,56 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
     const element = getElement(target);
     const elementRect = getClientRect(element);
     const isFixedTarget = hasPosition(element);
-    const top = getElementPosition(element, spotlightPadding, disableScrollParentFix);
+
+    let overridenHeight;
+
+    if (styles.spotlight.height) {
+      overridenHeight =
+        typeof styles.spotlight.height === 'number'
+          ? styles.spotlight.height
+          : Number(parseInt(styles.spotlight.height, 10));
+    }
+
+    let overridenWidth;
+
+    if (styles.spotlight.width) {
+      overridenWidth =
+        typeof styles.spotlight.width === 'number'
+          ? styles.spotlight.width
+          : Number(parseInt(styles.spotlight.width, 10));
+    }
+
+    let overridenLeft;
+
+    if (styles.spotlight.left) {
+      overridenLeft =
+        typeof styles.spotlight.left === 'number'
+          ? styles.spotlight.left
+          : Number(parseInt(styles.spotlight.left, 10));
+    }
+
+    let overridenTop;
+
+    if (styles.spotlight.top) {
+      overridenTop =
+        typeof styles.spotlight.top === 'number'
+          ? styles.spotlight.top
+          : Number(parseInt(styles.spotlight.top, 10));
+    }
+
+    const top =
+      overridenTop ?? getElementPosition(element, spotlightPadding, disableScrollParentFix);
 
     return {
-      height: Math.round((elementRect?.height ?? 0) + spotlightPadding * 2),
-      left: Math.round((elementRect?.left ?? 0) - spotlightPadding),
+      ...(isLegacy() ? styles.spotlightLegacy : styles.spotlight),
+      height: Math.round((overridenHeight ?? elementRect?.height ?? 0) + spotlightPadding * 2),
+      left: Math.round((overridenLeft ?? elementRect?.left ?? 0) - spotlightPadding),
       opacity: showSpotlight ? 1 : 0,
       pointerEvents: spotlightClicks ? 'none' : 'auto',
       position: isFixedTarget ? 'fixed' : 'absolute',
       top,
       transition: 'opacity 0.2s',
-      width: Math.round((elementRect?.width ?? 0) + spotlightPadding * 2),
-      ...(isLegacy() ? styles.spotlightLegacy : styles.spotlight),
+      width: overridenWidth || Math.round((elementRect?.width ?? 0) + spotlightPadding * 2),
     } satisfies React.CSSProperties;
   }
 

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -107,55 +107,55 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
     const elementRect = getClientRect(element);
     const isFixedTarget = hasPosition(element);
 
-    let overridenHeight;
+    let overriddenHeight;
 
     if (styles.spotlight.height) {
-      overridenHeight =
+      overriddenHeight =
         typeof styles.spotlight.height === 'number'
           ? styles.spotlight.height
           : Number(parseInt(styles.spotlight.height, 10));
     }
 
-    let overridenWidth;
+    let overriddenWidth;
 
     if (styles.spotlight.width) {
-      overridenWidth =
+      overriddenWidth =
         typeof styles.spotlight.width === 'number'
           ? styles.spotlight.width
           : Number(parseInt(styles.spotlight.width, 10));
     }
 
-    let overridenLeft;
+    let overriddenLeft;
 
     if (styles.spotlight.left) {
-      overridenLeft =
+      overriddenLeft =
         typeof styles.spotlight.left === 'number'
           ? styles.spotlight.left
           : Number(parseInt(styles.spotlight.left, 10));
     }
 
-    let overridenTop;
+    let overriddenTop;
 
     if (styles.spotlight.top) {
-      overridenTop =
+      overriddenTop =
         typeof styles.spotlight.top === 'number'
           ? styles.spotlight.top
           : Number(parseInt(styles.spotlight.top, 10));
     }
 
     const top =
-      overridenTop ?? getElementPosition(element, spotlightPadding, disableScrollParentFix);
+      overriddenTop ?? getElementPosition(element, spotlightPadding, disableScrollParentFix);
 
     return {
       ...(isLegacy() ? styles.spotlightLegacy : styles.spotlight),
-      height: Math.round((overridenHeight ?? elementRect?.height ?? 0) + spotlightPadding * 2),
-      left: Math.round((overridenLeft ?? elementRect?.left ?? 0) - spotlightPadding),
+      height: Math.round((overriddenHeight ?? elementRect?.height ?? 0) + spotlightPadding * 2),
+      left: Math.round((overriddenLeft ?? elementRect?.left ?? 0) - spotlightPadding),
       opacity: showSpotlight ? 1 : 0,
       pointerEvents: spotlightClicks ? 'none' : 'auto',
       position: isFixedTarget ? 'fixed' : 'absolute',
       top,
       transition: 'opacity 0.2s',
-      width: overridenWidth || Math.round((elementRect?.width ?? 0) + spotlightPadding * 2),
+      width: overriddenWidth || Math.round((elementRect?.width ?? 0) + spotlightPadding * 2),
     } satisfies React.CSSProperties;
   }
 


### PR DESCRIPTION
When <Joyride /> is used as third party lib in host react applications, there are several instances where you might need a more finer control on how things are displayed. This change allows developers to manipulate spotlight style if they want according to their needs.

In our case, we are using <Joyride /> with react-pdf to create highlighted section in the pdf. So we need finer control over the spotlight CSS being displayed in our app.