### PR TITLE
fix(joyride): fix nested buttons warning

### DIFF
--- a/src/components/Tooltip/Container.tsx
+++ b/src/components/Tooltip/Container.tsx
@@ -49,36 +49,25 @@ function JoyrideTooltipContainer(props: TooltipRenderProps) {
 
   if (output.primary) {
     output.primary = (
-      <button
-        data-test-id="button-primary"
-        style={styles.buttonNext}
-        type="button"
-        {...primaryProps}
-      >
+      <div data-test-id="button-primary" style={styles.buttonNext} {...primaryProps}>
         {output.primary}
-      </button>
+      </div>
     );
   }
 
   if (showSkipButton && !isLastStep) {
     output.skip = (
-      <button
-        aria-live="off"
-        data-test-id="button-skip"
-        style={styles.buttonSkip}
-        type="button"
-        {...skipProps}
-      >
+      <div aria-live="off" data-test-id="button-skip" style={styles.buttonSkip} {...skipProps}>
         {skip}
-      </button>
+      </div>
     );
   }
 
   if (!hideBackButton && index > 0) {
     output.back = (
-      <button data-test-id="button-back" style={styles.buttonBack} type="button" {...backProps}>
+      <div data-test-id="button-back" style={styles.buttonBack} {...backProps}>
         {back}
-      </button>
+      </div>
     );
   }
 


### PR DESCRIPTION
## The warning

![image](https://github.com/gilbarbara/react-joyride/assets/65162638/54d42dcc-d462-4c7e-a65c-273a698053b1)

## How to reproduce
Since a button cannot be a child of another button, the warning is issued any time a `<button />` is used as `locale` for `next`, `skip` or `back`.  So in order for `locale` prop to accept any `ReactNode` I think it should wrap that in a `div` instead of a `button` or alternatively only wrap in a button locales of type string.

## Why is it needed
This could be really useful to use button components from visual element libraries instead on leveraging on css styles only.

## Why this is not going to break everything

I ran the `react-joyride-demo` and the playwright tests