### PR TITLE
Update CallBackProps' origin to be optional

### DIFF
--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -121,7 +121,7 @@ export type CallBackProps = {
   /**
    * The element that triggered the action (if available).
    */
-  origin: Origin | null;
+  origin?: Origin | null;
   /**
    * The number of steps
    */


### PR DESCRIPTION
Since origin is only passed if available and can be null, it should be optional.