### PR TITLE
Fix scrollbar flickering on tour navigation

### DIFF
--- a/src/components/Step.tsx
+++ b/src/components/Step.tsx
@@ -239,6 +239,15 @@ export default class JoyrideStep extends React.Component<StepProps> {
           id={`react-joyride-step-${index}`}
           open={this.open}
           placement={step.placement}
+          styles={{
+            ...step.floaterProps?.styles,
+            floater: {
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              ...step.floaterProps?.styles?.floater,
+            },
+          }}
           target={step.target}
         >
           <Beacon

--- a/test/tours/__snapshots__/controlled.spec.tsx.snap
+++ b/test/tours/__snapshots__/controlled.spec.tsx.snap
@@ -1082,7 +1082,7 @@ exports[`Joyride > Controlled > should start the tour 2`] = `
 >
   <div
     class="__floater __floater__open"
-    style="display: inline-block; filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.3)); max-width: 100%; opacity: 1; position: absolute; transition: opacity 0.3s, transform 0.2s; visibility: visible; z-index: 10100; padding: 16px 0px 0px; transform: translate3d(NaNpx, NaNpx, 0); top: 0px; left: 0px; will-change: transform;"
+    style="display: inline-block; filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.3)); max-width: 100%; opacity: 1; position: absolute; transition: opacity 0.3s, transform 0.2s; visibility: visible; z-index: 10100; padding: 16px 0px 0px; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0); will-change: transform;"
     x-placement="bottom"
   >
     <div

--- a/test/tours/__snapshots__/custom-options.spec.tsx.snap
+++ b/test/tours/__snapshots__/custom-options.spec.tsx.snap
@@ -306,7 +306,7 @@ exports[`Joyride > Custom Options > should render the STEP 3 Beacon 1`] = `
 exports[`Joyride > Custom Options > should render the STEP 3 Tooltip 1`] = `
 <div
   class="__floater"
-  style="display: inline-block; filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.3)); max-width: 100%; opacity: 1; position: absolute; transition: opacity 0.3s; visibility: visible; z-index: 200; padding: 0px 16px 0px 0px; transform: translate3d(NaNpx, NaNpx, 0); top: 0px; left: 0px; will-change: transform;"
+  style="display: inline-block; filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.3)); max-width: 100%; opacity: 1; position: absolute; transition: opacity 0.3s; visibility: visible; z-index: 200; padding: 0px 16px 0px 0px; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0); will-change: transform;"
   x-placement="left"
 >
   <div

--- a/test/tours/__snapshots__/standard.spec.tsx.snap
+++ b/test/tours/__snapshots__/standard.spec.tsx.snap
@@ -237,7 +237,7 @@ exports[`Joyride > Standard > should start the tour 1`] = `
 >
   <div
     class="__floater"
-    style="display: inline-block; filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.3)); max-width: 100%; opacity: 0; position: absolute; transition: opacity 0.3s; visibility: hidden; z-index: 200; padding: 16px 0px 0px;"
+    style="display: inline-block; filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.3)); max-width: 100%; opacity: 0; position: absolute; transition: opacity 0.3s; visibility: hidden; z-index: 200; top: 0px; left: 0px; padding: 16px 0px 0px;"
     x-placement="bottom"
   >
     <div


### PR DESCRIPTION
Related to #1115 

The problem seems to be that the floater element is initially positioned at the bottom of the page and therefore takes additional space. This results in the appearance of the scroll bar until the floater element is correctly positioned. I could fix it by setting some absolute styles. However, this seems to be a workaround and the underlying issue may actually be in the react-floater library.