### PR TITLE
Use floater props target element to be able to change the tooltip location

### DIFF
--- a/src/components/Step.tsx
+++ b/src/components/Step.tsx
@@ -223,7 +223,8 @@ export default class JoyrideStep extends React.Component<StepProps> {
 
   render() {
     const { continuous, debug, index, nonce, shouldScroll, size, step } = this.props;
-    const target = getElement(step.target);
+    const target =
+      getElement(step.floaterProps?.target as string | HTMLElement) || getElement(step.target);
 
     if (!validateStep(step) || !is.domElement(target)) {
       return null;
@@ -239,7 +240,7 @@ export default class JoyrideStep extends React.Component<StepProps> {
           id={`react-joyride-step-${index}`}
           open={this.open}
           placement={step.placement}
-          target={step.target}
+          target={target}
         >
           <Beacon
             beaconComponent={step.beaconComponent}


### PR DESCRIPTION
I came up with a product requirement that I have to show tooltip on a specific element within a spotlight box. So I saw that there is prop name `floaterProps` that accepts a target string but it is not being used in the package. 

So my changes will check if `target` prop is given in the f`loaterProps` then use it otherwise use the parent `target` (spotlight box).
