### PR TITLE
fix(useTourEngine): start tour when run is true and steps load after mount

### DIFF
--- a/src/hooks/useTourEngine.ts
+++ b/src/hooks/useTourEngine.ts
@@ -70,9 +70,13 @@ export default function useTourEngine(props: Props): UseTourEngineReturn {
 
   useUpdateEffect(() => {
     if (run && size && status === STATUS.IDLE) {
-      store.current.updateState({ status: STATUS.READY });
+      if (validateSteps(steps, debug)) {
+        controls.start(stepIndex ?? initialStepIndex);
+      } else {
+        store.current.updateState({ status: STATUS.READY });
+      }
     }
-  }, [run, size, status]);
+  }, [controls, debug, initialStepIndex, run, size, status, stepIndex, steps]);
 
   usePropSync({
     controls,

--- a/test/hooks/useTourEngine.spec.ts
+++ b/test/hooks/useTourEngine.spec.ts
@@ -841,6 +841,26 @@ describe('useTourEngine', () => {
         expect(result.current.state.size).toBe(3);
       });
     });
+
+    it('should start the tour when run is already true and steps arrive after mount', async () => {
+      const { rerender, result } = renderHook((props: Props) => useTourEngine(props), {
+        initialProps: createProps({ run: true, steps: [] }),
+      });
+
+      expect(result.current.state.status).toBe(STATUS.IDLE);
+      expect(mockOnEvent).not.toHaveBeenCalled();
+
+      rerender(createProps({ run: true, steps: testSteps }));
+
+      await waitFor(() => {
+        expect(result.current.state.status).toBe(STATUS.RUNNING);
+      });
+
+      expect(mockOnEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: EVENTS.TOUR_START }),
+        expectControls(),
+      );
+    });
   });
 
   describe('Scroll', () => {


### PR DESCRIPTION
Addresses #1211 

The fix matches the mount effect, i.e., when `run && size && status === idle`, start the tour if the steps validate.

- The `else` branch keeps the prior `idle → ready` behavior for **invalid** steps, so the only behavioral change is that **valid** steps now start.
- Every added dep is a stable reference or a primitive, and the `status === IDLE` guard makes any extra fire a no-op, so there's no re-render churn and no double-start with `usePropSync` (both the "run already true" and "run toggled" paths start exactly once).

One new regression test for this has been added in `test/hooks/useTourEngine.spec.ts`. The full suite passes, and there are no API changes.