### PR TITLE
fix: start tour when async steps load

### DIFF
--- a/src/hooks/useTourEngine.ts
+++ b/src/hooks/useTourEngine.ts
@@ -70,9 +70,9 @@ export default function useTourEngine(props: Props): UseTourEngineReturn {
 
   useUpdateEffect(() => {
     if (run && size && status === STATUS.IDLE) {
-      store.current.updateState({ status: STATUS.READY });
+      controls.start(stepIndex ?? initialStepIndex);
     }
-  }, [run, size, status]);
+  }, [controls, initialStepIndex, run, size, status, stepIndex]);
 
   usePropSync({
     controls,

--- a/test/hooks/useTourEngine.spec.ts
+++ b/test/hooks/useTourEngine.spec.ts
@@ -990,6 +990,30 @@ describe('useTourEngine', () => {
       }).not.toThrow();
     });
 
+    it('should start when run is true and steps are added after mount', async () => {
+      const { rerender, result } = renderHook((props: Props) => useTourEngine(props), {
+        initialProps: createProps({ steps: [] }),
+      });
+
+      expect(result.current.state.status).toBe(STATUS.IDLE);
+
+      rerender(createProps({ steps: testSteps }));
+
+      await waitFor(() => {
+        expect(result.current.state.status).toBe(STATUS.RUNNING);
+      });
+
+      expect(mockOnEvent).toHaveBeenCalledWith(
+        getEventResponse({
+          action: ACTIONS.START,
+          index: 0,
+          lifecycle: LIFECYCLE.INIT,
+          type: EVENTS.TOUR_START,
+        }),
+        expectControls(),
+      );
+    });
+
     it('should use TOOLTIP for center placement (beacon hidden)', async () => {
       const steps: Step[] = [{ target: '.step-1', content: 'Step 1', placement: 'center' }];
 


### PR DESCRIPTION
## Summary

- start the tour when `run` is already `true` and asynchronously loaded `steps` transition the store out of `idle`
- use the normal `controls.start()` path so the store reaches `running`, emits `tour:start`, and respects `stepIndex` / `initialStepIndex`
- add regression coverage for empty steps at mount followed by populated steps

## Testing

- `pnpm test` (479 tests)
- `pnpm typecheck`
- `pnpm exec eslint src test e2e` (0 errors)
- `pnpm build`
- `pnpm size`
- `pnpm typevalidation`

Closes #1211